### PR TITLE
Fix minor bug in exportAsCSV (output was not written to file)

### DIFF
--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
@@ -76,12 +76,13 @@ class DexMethodCountTask extends DefaultTask {
             outputFileCSV.parentFile.mkdirs()
             outputFileCSV.createNewFile()
 
-            if (config.includeFieldCount) {
-                outputFileCSV.println("methods,fields")
-                outputFileCSV.println("${methodCount},${fieldCount}")
-            } else {
-                outputFileCSV.println("methods")
-                outputFileCSV.println("${methodCount}")
+            final String headers = config.includeFieldCount ? "methods,fields" : "methods";
+            final String counts = config.includeFieldCount ? "${methodCount},${fieldCount}" : "${methodCount}";
+
+            outputFileCSV.withOutputStream { stream ->
+                def appendableStream = new PrintStream(stream)
+                appendableStream.println(headers)
+                appendableStream.println(counts);
             }
         }
     }


### PR DESCRIPTION
While testing out the SNAPSHOT with the exportAsCSV functionality, I saw that the output was printed onto the terminal and not into the file.

This should fix it. I'm sorry for the inconveniences.