### PR TITLE
Reduce non-existing mapping file statement to DEBUG

### DIFF
--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
@@ -159,9 +159,10 @@ class DexMethodCountTask extends DefaultTask {
 
     private def getDeobfuscator() {
         if (mappingFile != null && !mappingFile.exists()) {
-            withStyledOutput(StyledTextOutput.Style.Error, LogLevel.WARN) {
-                it.println("Mapping file specified at ${mappingFile.absolutePath} does not exist, output will be obfuscated")
+            withStyledOutput(StyledTextOutput.Style.Normal, LogLevel.DEBUG) {
+                it.println("Mapping file specified at ${mappingFile.absolutePath} does not exist, assuming output is not obfuscated.")
             }
+            mappingFile = null
         }
 
         return Deobfuscator.create(mappingFile)


### PR DESCRIPTION
When proguard is enabled with `-dontobfuscate`, the variant will have a non-null mapping file object, but no mapping file will be written.  Previously we treated this as a strange failure, but apparently it is a normal condition.