### PR TITLE
Remove `exportAsCSV`, print the summary every time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.3.0 (Unreleased)
 ----------
 
+* Remove `exportAsCSV` and just print the file unconditionally
 * CHANGED: field counts are enabled by default
 * Use Proguard mappings to de-obfuscate class and package names
 * Add `exportAsCSV` option to support Jenkins Plot Plugin

--- a/README.md
+++ b/README.md
@@ -79,11 +79,10 @@ in `app/build.gradle`:
 ```groovy
 dexcount {
     includeClasses = false
-    includeFieldCount = false
+    includeFieldCount = true
     printAsTree = false
     orderByMethodCount = false
     verbose = false
-    exportAsCSV = false
 }
 ```
 
@@ -93,7 +92,6 @@ Each flag controls some aspect of the printed output:
 - `printAsTree`: When true, the output file will be formatted as a package tree, with nested packages indented, instead of the default list format.
 - `orderByMethodCount`: When true, packages will be sorted in descending order by the number of methods they contain.
 - `verbose`: When true, the output file will also be printed to the build's standard output.
-- `exportAsCSV`: When true, the task will create a csv file with the summary: number of methods plus number of fields if includeFieldCount is true.
 
 ## Use with Jenkins Plot Plugin
 

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountExtension.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountExtension.groovy
@@ -25,7 +25,6 @@ class DexMethodCountExtension {
     private boolean includeFieldCount = true
     private boolean printAsTree
     private boolean verbose
-    private boolean exportAsCSV
 
     /**
      * When true, includes individual classes in task output.
@@ -85,16 +84,5 @@ class DexMethodCountExtension {
 
     public void setOrderByMethodCount(boolean orderByMethodCount) {
         this.orderByMethodCount = orderByMethodCount
-    }
-
-    /**
-     * When true, the task will create a csv file with the summary: number of methods plus number of fields if includeFieldCount is true.
-     */
-    public boolean getExportAsCSV() {
-        return this.exportAsCSV
-    }
-
-    public void setExportAsCSV(boolean exportAsCSV) {
-        this.exportAsCSV = exportAsCSV
     }
 }

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
@@ -50,8 +50,8 @@ class DexMethodCountPlugin implements Plugin<Project> {
                 DexMethodCountTask task = project.tasks.create("count${slug}DexMethods", DexMethodCountTask)
                 task.apkOrDex = output
                 task.mappingFile = variant.mappingFile
-                task.outputFileTxt = project.file(path + '.txt')
-                task.outputFileCSV = project.file(path + '.csv')
+                task.outputFile = project.file(path + '.txt')
+                task.summaryFile = project.file(path + '.csv')
                 task.config = ext as DexMethodCountExtension
                 variant.assemble.doLast { task.countMethods() }
             }


### PR DESCRIPTION
I'm unhappy with the proliferation of config options.  None of them (except `includeClassNames`, `printAsTree`, and `verbose`) are particularly useful, especially `exportAsCSV`.  The file it generates, however, is unquestionably useful.  We've had several user issues where summary counts were needed, and having a dedicated output file is far better than handing out awk snippets.

So - we kill the config knob and make the API simpler, and retain the useful part.  Along with that, the plugin task is cleaned up quite a bit as well.