### PR TITLE
fix error apkOrDex can't be serialized.

### DIFF
--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
@@ -48,7 +48,7 @@ class DexMethodCountPlugin implements Plugin<Project> {
                 def ext = project.extensions['dexcount']
 
                 DexMethodCountTask task = project.tasks.create("count${slug}DexMethods", DexMethodCountTask)
-                task.apkOrDex = output
+                task.apkOrDexFile = output.outputFile
                 task.mappingFile = variant.mappingFile
                 task.outputFile = project.file(path + '.txt')
                 task.summaryFile = project.file(path + '.csv')

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
@@ -34,7 +34,7 @@ class DexMethodCountTask extends DefaultTask {
     def PackageTree tree;
 
     @Input
-    def BaseVariantOutput apkOrDex
+    def File apkOrDexFile
 
     @Nullable
     def File mappingFile
@@ -60,7 +60,7 @@ class DexMethodCountTask extends DefaultTask {
      * @return
      */
     def printSummary() {
-        def filename = apkOrDex.outputFile.name
+        def filename = apkOrDexFile.name
         withStyledOutput(StyledTextOutput.Style.Info) { out ->
             out.println("Total methods in ${filename}: ${tree.methodCount}")
             out.println("Total fields in ${filename}:  ${tree.fieldCount}")
@@ -139,7 +139,7 @@ class DexMethodCountTask extends DefaultTask {
         // If none is given, we'll get a default mapping.
         def deobs = getDeobfuscator()
 
-        def dataList = DexFile.extractDexData(apkOrDex.outputFile)
+        def dataList = DexFile.extractDexData(apkOrDexFile)
         try {
             tree = new PackageTree()
 


### PR DESCRIPTION
when execute task count**DexMethods. Thought dex methods
can be seen in console output. But there's an exception like
"Property 'apkOrDex' with value 'com.android.build.gradle.internal.api.ApkVariantOutputImpl_Decorated@1f61ab4' cannot be serialized."