### PR TITLE
CSS output file format added

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ dexcount {
     printAsTree = false
     orderByMethodCount = false
     verbose = false
+    cssFormat = false
 }
 ```
 
@@ -88,6 +89,7 @@ Each flag controls some aspect of the printed output:
 - `printAsTree`: When true, the output file will be formatted as a package tree, with nested packages indented, instead of the default list format.
 - `orderByMethodCount`: When true, packages will be sorted in descending order by the number of methods they contain.
 - `verbose`: When true, the output file will also be printed to the build's standard output.
+- `cssFormat`: When true, the output file will be formatted as CSS file to enable blocks folding/unfolding in Intellij or other editors.
 
 ## Use with Jenkins Plot Plugin
 

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountExtension.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountExtension.groovy
@@ -26,6 +26,7 @@ class DexMethodCountExtension {
     private boolean includeTotalMethodCount = false
     private boolean printAsTree
     private boolean verbose
+    private boolean cssFormat
 
     /**
      * When true, includes individual classes in task output.
@@ -96,5 +97,16 @@ class DexMethodCountExtension {
 
     public void setOrderByMethodCount(boolean orderByMethodCount) {
         this.orderByMethodCount = orderByMethodCount
+    }
+
+    /**
+     * When true, prints output in DSL format to support folding in editor.
+     */
+    public boolean getCssFormat() {
+        return cssFormat
+    }
+
+    public void setCssFormat(boolean dslFormat) {
+        this.cssFormat = dslFormat
     }
 }

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
@@ -52,9 +52,13 @@ class DexMethodCountPlugin implements Plugin<Project> {
                 task.group = 'Reporting'
                 task.apkOrDexFile = output.outputFile
                 task.mappingFile = variant.mappingFile
-                task.outputFile = project.file(path + '.txt')
-                task.summaryFile = project.file(path + '.csv')
                 task.config = ext as DexMethodCountExtension
+                if (task.config.cssFormat){
+                    task.outputFile = project.file(path + '.css')
+                } else {
+                    task.outputFile = project.file(path + '.txt')
+                }
+                task.summaryFile = project.file(path + '.csv')
                 variant.assemble.doLast { task.countMethods() }
             }
         }

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
@@ -186,7 +186,8 @@ class DexMethodCountTask extends DefaultTask {
                 includeTotalMethodCount: config.includeTotalMethodCount,
                 orderByMethodCount: config.orderByMethodCount,
                 includeClasses: config.includeClasses,
-                printHeader: true)
+                printHeader: true,
+                CSSFormat: config.cssFormat)
     }
 
     private def getDeobfuscator() {

--- a/src/main/groovy/com/getkeepsafe/dexcount/PackageTree.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/PackageTree.groovy
@@ -161,6 +161,8 @@ class PackageTree {
     }
 
     private void printTreeRecursively(Appendable out, int indent, PrintOptions opts) {
+        def children = getChildren(opts)
+
         if (opts.includeClasses || !isClass_) {
             indent.times { out.append("  ") }
             out.append(name_)
@@ -171,8 +173,10 @@ class PackageTree {
                 def appended = false
                 if (opts.includeMethodCount) {
                     out.append(String.valueOf(getMethodCount()))
-                    out.append(" ")
-                    out.append(pluralizedMethods(getMethodCount()))
+                    if (!opts.CSSFormat) {
+                        out.append(" ")
+                        out.append(pluralizedMethods(getMethodCount()))
+                    }
                     appended = true
                 }
 
@@ -181,17 +185,25 @@ class PackageTree {
                         out.append(", ")
                     }
                     out.append(String.valueOf(getFieldCount()))
-                    out.append(" ")
-                    out.append(pluralizeFields(getFieldCount()))
+                    if (!opts.CSSFormat) {
+                        out.append(" ")
+                        out.append(pluralizeFields(getFieldCount()))
+                    }
                 }
 
                 out.append(")")
             }
-
+            if (opts.CSSFormat && !children.isEmpty()) {
+                out.append(" {")
+            }
             out.append("\n")
         }
 
-        getChildren(opts).each { PackageTree it -> it.printTreeRecursively(out, indent + 1, opts) }
+        children.each { PackageTree it -> it.printTreeRecursively(out, indent + 1, opts) }
+        if (opts.CSSFormat && !children.isEmpty()) {
+            indent.times { out.append("  ") }
+            out.append("}\n")
+        }
     }
 
     private Collection<PackageTree> getChildren(PrintOptions opts) {

--- a/src/main/groovy/com/getkeepsafe/dexcount/PrintOptions.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/PrintOptions.groovy
@@ -23,4 +23,5 @@ class PrintOptions {
     def includeTotalMethodCount = false
     def printHeader = false
     def orderByMethodCount = false
+    def CSSFormat = false
 }


### PR DESCRIPTION
In my project I have a ~8000-lines file when I include classes. It's a pain to scroll it and to take advange of the tree structure. This improvement introduces code blocks near every package and allows folding and unfolding of these blocks in Intellij.