### PR TITLE
Add percentage of total methods project is taking up to output.

### DIFF
--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
@@ -30,6 +30,8 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.logging.StyledTextOutput
 import org.gradle.logging.StyledTextOutputFactory
 
+import java.text.DecimalFormat
+
 class DexMethodCountTask extends DefaultTask {
     /**
      * The maximum number of method refs and field refs allowed in a single Dex
@@ -71,8 +73,9 @@ class DexMethodCountTask extends DefaultTask {
      */
     def printSummary() {
         def filename = apkOrDex.outputFile.name
+        def percentageRemaining = new DecimalFormat("##.##").format((tree.methodCount / MAX_DEX_REFS) * 100);
         withStyledOutput(StyledTextOutput.Style.Info) { out ->
-            out.println("Total methods in ${filename}: ${tree.methodCount}")
+            out.println("Total methods in ${filename}: ${tree.methodCount}  (${percentageRemaining}%)")
             out.println("Total fields in ${filename}:  ${tree.fieldCount}")
             out.println("Methods remaining in ${filename}: ${MAX_DEX_REFS - tree.methodCount}")
             out.println("Fields remaining in ${filename}:  ${MAX_DEX_REFS - tree.fieldCount}")

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
@@ -67,16 +67,19 @@ class DexMethodCountTask extends DefaultTask {
         printTaskDiagnosticData()
     }
 
+    private def getPercentageRemainingUntilMaxDefRefs(int count) {
+        return new DecimalFormat("##.##").format((count / MAX_DEX_REFS) * 100);
+    }
+
     /**
      * Prints a summary of method and field counts
      * @return
      */
     def printSummary() {
         def filename = apkOrDex.outputFile.name
-        def percentageRemaining = new DecimalFormat("##.##").format((tree.methodCount / MAX_DEX_REFS) * 100);
         withStyledOutput(StyledTextOutput.Style.Info) { out ->
-            out.println("Total methods in ${filename}: ${tree.methodCount}  (${percentageRemaining}%)")
-            out.println("Total fields in ${filename}:  ${tree.fieldCount}")
+            out.println("Total methods in ${filename}: ${tree.methodCount} (${getPercentageRemainingUntilMaxDefRefs(tree.methodCount)}%)")
+            out.println("Total fields in ${filename}:  ${tree.fieldCount} (${getPercentageRemainingUntilMaxDefRefs(tree.fieldCount)}%)")
             out.println("Methods remaining in ${filename}: ${MAX_DEX_REFS - tree.methodCount}")
             out.println("Fields remaining in ${filename}:  ${MAX_DEX_REFS - tree.fieldCount}")
         }


### PR DESCRIPTION
when I see the total method count output for my project, I don't find it super helpful because it is just a number. I want to see how much of the total 65,536 method count my project is taking up. 