### PR TITLE
Fix ctor-call-within-branch failure on buggy JVMs, again

### DIFF
--- a/src/main/groovy/com/getkeepsafe/dexcount/PackageTree.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/PackageTree.groovy
@@ -49,11 +49,15 @@ class PackageTree {
     // nodes and possibly non-empty for class nodes.
     private final Set<HasDeclaringClass> fields_ = new HashSet<>()
 
-    PackageTree(Deobfuscator deobfuscator = null) {
+    PackageTree() {
+        this("", false, null)
+    }
+
+    PackageTree(Deobfuscator deobfuscator) {
         this("", false, deobfuscator)
     }
 
-    PackageTree(String name, Deobfuscator deobfuscator = null) {
+    PackageTree(String name, Deobfuscator deobfuscator) {
         this(name, isClassName(name), deobfuscator)
     }
 


### PR DESCRIPTION
Fixes #12

This regressed when I added default-value parameters to PackageTree;
this compiles to an unholy horror of pass-args-by-global-static
dynamicism and other unspeakables, including the verifier crash.

This PR removes default parameters, restoring order to PackageTree
once again.