### PR TITLE
Don't crash when parsing dex data fails

### DIFF
--- a/src/main/groovy/com/getkeepsafe/dexcount/DexCountException.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexCountException.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 KeepSafe Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.getkeepsafe.dexcount
+
+class DexCountException extends RuntimeException {
+    DexCountException() {}
+    DexCountException(String message) { super(message) }
+    DexCountException(String message, Throwable cause) { super(message, cause) }
+}

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
@@ -64,11 +64,18 @@ class DexMethodCountTask extends DefaultTask {
 
     @TaskAction
     void countMethods() {
-        generatePackageTree()
-        printSummary()
-        printFullTree()
-        printChart()
-        printTaskDiagnosticData()
+        try {
+            generatePackageTree()
+            printSummary()
+            printFullTree()
+            printChart()
+            printTaskDiagnosticData()
+        } catch (DexCountException e) {
+            withStyledOutput(StyledTextOutput.Style.Error, LogLevel.ERROR) { out ->
+                out.println("Error counting dex methods.  Please contact the developer at https://github.com/KeepSafe/dexcount-gradle-plugin/issues")
+                out.exception(e)
+            }
+        }
     }
 
     static def percentUsed(int count) {


### PR DESCRIPTION
We shouldn't cause build failures when dexcount fails.

This PR catches and logs exceptions, but doesn't fail the build.  Fixes #83.