### PR TITLE
Dedupe task invocations

### DIFF
--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
@@ -64,7 +64,13 @@ class DexMethodCountPlugin implements Plugin<Project> {
                 task.summaryFile = project.file(path + '.csv')
                 task.chartDir = project.file(path + 'Chart')
                 task.config = ext
-                variant.assemble.doLast { task.countMethods() }
+
+                // Dexcount tasks require that assemble has been run...
+                task.dependsOn(variant.assemble)
+                task.mustRunAfter(variant.assemble)
+
+                // But assemble should always imply that dexcount runs, too.
+                variant.assemble.finalizedBy(task)
             }
         }
     }


### PR DESCRIPTION
Per #96, we have been misusing the Gradle API.  This commit uses the
task-ordering APIs to a) require that assemble runs before dexcount, and
b) ensure that running assemble triggers dexcount.

Fixes #96