### PR TITLE
Support Java 7

### DIFF
--- a/src/main/groovy/com/getkeepsafe/dexcount/DexFile.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexFile.groovy
@@ -111,7 +111,12 @@ class DexFile {
         def proc = dxCmd.execute()
         proc.consumeProcessOutput(sout, serr)
 
-        if (!proc.waitFor(dxTimeoutSecs, TimeUnit.SECONDS)) {
+        try {
+            TimeUnit.SECONDS.sleep(dxTimeoutSecs);
+        } catch (InterruptedException e) {
+            // No big deal
+        }
+        if (proc.isAlive()) {
             proc.destroyForcibly()
             throw new DexCountException("dx timed out after $dxTimeoutSecs seconds")
         }


### PR DESCRIPTION
Process.waitFor(long, TimeUnit) was added to Java 8. Achieve the same by
just Thread.sleep()-ing for some time and check if the process is still
alive.