### PR TITLE
Print plugin name and version when invoked with '--stacktrace'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,14 @@ sourceSets {
     }
 }
 
+jar {
+    manifest {
+        attributes(
+                'Implementation-Title':   POM_ARTIFACT_ID,
+                'Implementation-Version': VERSION_NAME)
+    }
+}
+
 repositories {
     mavenCentral()
 }

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountExtension.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountExtension.groovy
@@ -27,6 +27,7 @@ class DexMethodCountExtension {
     private boolean teamCityIntegration = false
     private OutputFormat format = OutputFormat.LIST
     private boolean verbose
+    private boolean printVersion
     private int maxTreeDepth = Integer.MAX_VALUE
     private int dxTimeoutSec = 60;
 
@@ -118,6 +119,14 @@ class DexMethodCountExtension {
 
     void setDxTimeoutSec(int dxTimeoutSec) {
         this.dxTimeoutSec = dxTimeoutSec
+    }
+
+    boolean getPrintVersion() {
+        return this.printVersion
+    }
+
+    void setPrintVersion(boolean printVersion) {
+        this.printVersion = printVersion;
     }
 
     public void setFormat(Object format) {

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
@@ -21,6 +21,7 @@ import com.getkeepsafe.dexcount.sdkresolver.SdkResolver
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.logging.ShowStacktrace
 
 class DexMethodCountPlugin implements Plugin<Project> {
     public static File sdkLocation = SdkResolver.resolve(null)
@@ -54,6 +55,13 @@ class DexMethodCountPlugin implements Plugin<Project> {
 
                 def ext = project.extensions['dexcount'] as DexMethodCountExtension
                 def format = ext.format
+
+                // If the user has passed '--stacktrace' or '--full-stacktrace', assume
+                // that they are trying to report a dexcount bug.  Help us help them out
+                // by printing the current plugin title and version.
+                if (project.gradle.startParameter.showStacktrace != ShowStacktrace.INTERNAL_EXCEPTIONS) {
+                    ext.printVersion = true
+                }
 
                 def task = project.tasks.create("count${slug}DexMethods", DexMethodCountTask)
                 task.description = "Outputs dex method count for ${variant.name}."

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
@@ -66,6 +66,7 @@ class DexMethodCountTask extends DefaultTask {
     @TaskAction
     void countMethods() {
         try {
+            printPreamble()
             generatePackageTree()
             printSummary()
             printFullTree()
@@ -82,6 +83,18 @@ class DexMethodCountTask extends DefaultTask {
     static def percentUsed(int count) {
         def used = ((double) count / MAX_DEX_REFS) * 100.0
         return sprintf("%.2f", used)
+    }
+
+    def printPreamble() {
+        if (config.printVersion) {
+            def projectName = getClass().package.implementationTitle
+            def projectVersion = getClass().package.implementationVersion
+
+            withStyledOutput(StyledTextOutput.Style.Normal) { out ->
+                out.println("Dexcount name:    $projectName")
+                out.println("Dexcount version: $projectVersion")
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This will cut time-to-resolution on a good number of Github issues,
many of which result from running an outdated plugin version.