### PR TITLE
Remove direct references to ShowStacktrace

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
@@ -21,7 +21,6 @@ import com.getkeepsafe.dexcount.sdkresolver.SdkResolver
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.logging.ShowStacktrace
 
 class DexMethodCountPlugin implements Plugin<Project> {
     public static File sdkLocation = SdkResolver.resolve(null)
@@ -59,7 +58,7 @@ class DexMethodCountPlugin implements Plugin<Project> {
                 // If the user has passed '--stacktrace' or '--full-stacktrace', assume
                 // that they are trying to report a dexcount bug.  Help us help them out
                 // by printing the current plugin title and version.
-                if (project.gradle.startParameter.showStacktrace != ShowStacktrace.INTERNAL_EXCEPTIONS) {
+                if (GradleApi.isShowStacktrace(project.gradle.startParameter)) {
                     ext.printVersion = true
                 }
 

--- a/src/main/groovy/com/getkeepsafe/dexcount/GradleApi.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/GradleApi.groovy
@@ -1,0 +1,30 @@
+package com.getkeepsafe.dexcount
+
+import org.codehaus.groovy.runtime.InvokerHelper;
+import org.gradle.StartParameter;
+
+/**
+ * Attempts to isolate our use bits of the Gradle API that have changed in
+ * incompatible ways over time.
+ */
+final class GradleApi {
+    private GradleApi() {
+        // no instances
+    }
+
+    /**
+     * Return {@code true} if Gradle was launched with {@code --stacktrace},
+     * otherwise {@code false}.
+     *
+     * <p>Gradle broke compatibility between 2.13 and 2.14 by repackaging
+     * the {@code ShowStacktrace} enum; consequently we need to refer to
+     * it by string name only.
+     *
+     * @param startParam
+     */
+    static boolean isShowStacktrace(StartParameter startParam) {
+        Enum stacktrace = (Enum) InvokerHelper.invokeMethod(
+                startParam, "getShowStacktrace", null);
+        return !"INTERNAL_EXCEPTIONS".equals(stacktrace.name());
+    }
+}


### PR DESCRIPTION
Gradle 2.14 repackaged the ShowStacktrace enum, breaking us at the
apply stage.  It is still an enum and still has the same constants, so
we can access it dynamically and match on its `name()`.

Fixes #109.