### PR TITLE
Add configurable slug for TeamCity statistics

### DIFF
--- a/.buildscript/test.sh
+++ b/.buildscript/test.sh
@@ -27,6 +27,9 @@ grep -F 'Total fields in app-debug.apk:  7093 (10.82% used)' app.log || die "Inc
 grep -F 'Methods remaining in app-debug.apk: 49361' app.log || die "Incorrect remaining-method value in app-debug.apk"
 grep -F 'Fields remaining in app-debug.apk:  58442' app.log || die "Incorrect remaining-field value in app-debug.apk"
 
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_MethodCount' value='16174']" app.log || die "Missing or incorrect Teamcity method count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_FieldCount' value='7093']" app.log || die "Missing or incorrect Teamcity field count value"
+
 grep -F 'Total methods in tests-debug.apk: 3065 (4.68% used)' tests.log || die "Incorrect method count in tests-debug.apk"
 grep -F 'Total fields in tests-debug.apk:  771 (1.18% used)' tests.log || die "Incorrect field count in tests-debug.apk"
 grep -F 'Methods remaining in tests-debug.apk: 62470' tests.log || die "Incorrect remaining-method value in tests-debug.apk"

--- a/integration/app/build.gradle
+++ b/integration/app/build.gradle
@@ -27,6 +27,7 @@ android {
 
 dexcount {
     verbose = true
+    teamCitySlug = project.name
 }
 
 dependencies {

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountExtension.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountExtension.groovy
@@ -31,6 +31,7 @@ class DexMethodCountExtension {
     private boolean printVersion
     private int maxTreeDepth = Integer.MAX_VALUE
     private int dxTimeoutSec = 60;
+    private String teamCitySlug = null
 
     /**
      * When true, includes individual classes in task output.
@@ -149,5 +150,13 @@ class DexMethodCountExtension {
 
     public void setEnableForInstantRun(boolean enableForInstantRun) {
         this.enableForInstantRun = enableForInstantRun;
+    }
+
+    public String getTeamCitySlug() {
+        return teamCitySlug
+    }
+
+    public void setTeamCitySlug(String teamcitySlug) {
+        this.teamCitySlug = teamcitySlug
     }
 }

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
@@ -133,10 +133,16 @@ class DexMethodCountTask extends DefaultTask {
             }
         }
 
-        if (getPrintOptions().teamCityIntegration) {
+        if (getPrintOptions().teamCityIntegration || config.teamCitySlug != null) {
             withStyledOutput() { out ->
-                printTeamCityStatisticValue(out, "DexCount_${apkOrDex.name}_MethodCount", tree.methodCount.toString())
-                printTeamCityStatisticValue(out, "DexCount_${apkOrDex.name}_FieldCount", tree.fieldCount.toString())
+                def prefix = "Dexcount"
+                if (config.teamCitySlug != null) {
+                    def slug = config.teamCitySlug.replace(' ', '_') // Not sure how TeamCity would handle spaces?
+                    prefix = "${prefix}_${slug}"
+                }
+
+                printTeamCityStatisticValue(out, "${prefix}_${apkOrDex.name}_MethodCount", tree.methodCount)
+                printTeamCityStatisticValue(out, "${prefix}_${apkOrDex.name}_FieldCount", tree.fieldCount)
             }
         }
     }
@@ -145,7 +151,7 @@ class DexMethodCountTask extends DefaultTask {
      * Reports to Team City statistic value
      * Doc: https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingBuildStatistics
      */
-    def printTeamCityStatisticValue(Logger out, String key, String value) {
+    def printTeamCityStatisticValue(Logger out, String key, int value) {
         out.lifecycle("##teamcity[buildStatisticValue key='${key}' value='${value}']")
     }
 


### PR DESCRIPTION
This commit adds a config option providing a measure of customizability
to TeamCity statistic names, useful for projects with more than one APK
whose counts are tracked.

```gradle
dexcount {
  teamCitySlug = 'YourStringHere' // or project.name, etc
}
```

This slug defaults to null.  If given, it is inserted into the TeamCity
statistic key just after 'DexCount', e.g.
`DexCount_YourStringHere_debug_MethodCount`.

Fixes #128