### PR TITLE
Remove output annotations to opt out of Gradle caching

### DIFF
--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountTask.groovy
@@ -24,8 +24,6 @@ import groovy.transform.stc.SimpleType
 import org.gradle.api.DefaultTask
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 class DexMethodCountTask extends DefaultTask {
@@ -42,13 +40,8 @@ class DexMethodCountTask extends DefaultTask {
     @Nullable
     def File mappingFile
 
-    @OutputFile
     def File outputFile
-
-    @OutputFile
     def File summaryFile
-
-    @OutputDirectory
     def File chartDir
 
     def DexMethodCountExtension config


### PR DESCRIPTION
As it turns out, tasks with outputs but no inputs are considered by
Gradle to be up-to-date based on the outputs alone, meaning that you
can build, change your code, then rebuild, and not see updated counts.

This change removes the output annotations, fixing the staleness
problem - but also, opting out of Gradle's incremental builds entirely.

Fixes #131.