### PR TITLE
Add runOnEachAssemble option to prevent task from running after assemble

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ dexcount {
     teamCityIntegration = false
     enableForInstantRun = false
     teamCitySlug = null
+    runOnEachAssemble = true
 }
 ```
 
@@ -108,6 +109,7 @@ Each flag controls some aspect of the printed output:
 - `teamCityIntegration`: When true, Team City integration strings will be printed.
 - `enableForInstantRun`: When true, count methods even for Instant Run builds.  False by default.
 - `teamCitySlug`: A string which, if specified, will be added to TeamCity stat names.  Null by default.
+- `runOnEachAssemble`: When false, does not run count method during assemble task
 
 ## Use with Jenkins Plot Plugin
 

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountExtension.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountExtension.groovy
@@ -32,6 +32,7 @@ class DexMethodCountExtension {
     private int maxTreeDepth = Integer.MAX_VALUE
     private int dxTimeoutSec = 60;
     private String teamCitySlug = null
+    private boolean runOnEachAssemble = true
 
     /**
      * When true, includes individual classes in task output.
@@ -158,5 +159,13 @@ class DexMethodCountExtension {
 
     public void setTeamCitySlug(String teamcitySlug) {
         this.teamCitySlug = teamcitySlug
+    }
+
+    public boolean getRunOnEachAssemble() {
+        return runOnEachAssemble
+    }
+
+    public void setRunOnEachAssemble(boolean runOnEachAssemble) {
+        this.runOnEachAssemble = runOnEachAssemble
     }
 }

--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
@@ -117,7 +117,10 @@ class DexMethodCountPlugin implements Plugin<Project> {
         task.dependsOn(variant.assemble)
         task.mustRunAfter(variant.assemble)
 
-        // But assemble should always imply that dexcount runs, too.
-        variant.assemble.finalizedBy(task)
+        // But assemble should always imply that dexcount runs, unless configured not to.
+        def runOnEachAssemble = ext.runOnEachAssemble
+        if (runOnEachAssemble) {
+            variant.assemble.finalizedBy(task)
+        }
     }
 }


### PR DESCRIPTION
This PR adds a new option `runOnEachAssemble` to `dexcount` to allow `assemble` tasks to run without the `countDebugDexMethods` and `countReleaseDexMethods`.

Closes #125 