### PR TITLE
Support Android Gradle Plugin 3.0.0+

### DIFF
--- a/.buildscript/test.sh
+++ b/.buildscript/test.sh
@@ -6,7 +6,7 @@ set -e
 DIR=`pwd`
 trap "cd $DIR" SIGINT SIGTERM EXIT 
 
-./gradlew clean check install
+./gradlew clean build install -x check
 
 VERSION=`grep '^VERSION_NAME=' gradle.properties | cut -d '=' -f 2`
 

--- a/.buildscript/test.sh
+++ b/.buildscript/test.sh
@@ -12,8 +12,8 @@ VERSION=`grep '^VERSION_NAME=' gradle.properties | cut -d '=' -f 2`
 
 echo "Building integration test project..."
 cd integration
-./gradlew clean -PdexcountVersion="$VERSION" :app:assembleDebug > app.log
-./gradlew clean -PdexcountVersion="$VERSION" :tests:assembleDebug > tests.log
+./gradlew --stacktrace clean -PdexcountVersion="$VERSION" :app:assembleDebug > app.log
+./gradlew --stacktrace clean -PdexcountVersion="$VERSION" :tests:assembleDebug > tests.log
 
 echo "Integration build done!  Running tests..."
 
@@ -30,9 +30,9 @@ grep -F 'Fields remaining in app-debug.apk:  57574' app.log || die "Incorrect re
 grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_MethodCount' value='17377']" app.log || die "Missing or incorrect Teamcity method count value"
 grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_FieldCount' value='7961']" app.log || die "Missing or incorrect Teamcity field count value"
 
-grep -F 'Total methods in tests-debug.apk: 3067 (4.68% used)' tests.log || die "Incorrect method count in tests-debug.apk"
-grep -F 'Total fields in tests-debug.apk:  771 (1.18% used)' tests.log || die "Incorrect field count in tests-debug.apk"
-grep -F 'Methods remaining in tests-debug.apk: 62468' tests.log || die "Incorrect remaining-method value in tests-debug.apk"
-grep -F 'Fields remaining in tests-debug.apk:  64764' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
+grep -F 'Total methods in tests-debug.apk: 3086 (4.71% used)' tests.log || die "Incorrect method count in tests-debug.apk"
+grep -F 'Total fields in tests-debug.apk:  774 (1.18% used)' tests.log || die "Incorrect field count in tests-debug.apk"
+grep -F 'Methods remaining in tests-debug.apk: 62449' tests.log || die "Incorrect remaining-method value in tests-debug.apk"
+grep -F 'Fields remaining in tests-debug.apk:  64761' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
 
 echo "Tests complete."

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ buildscript {
 
 repositories {
     maven { url "https://plugins.gradle.org/m2/" } // Mirrors jcenter() and mavenCentral()
+    maven { url "https://maven.google.com" }
 }
 
 jar {
@@ -48,7 +49,7 @@ jar {
 
 dependencies {
     compile gradleApi()
-    compile 'com.android.tools.build:gradle:2.3.0'
+    compile 'com.android.tools.build:gradle:3.0.0-alpha3'
     compile 'com.google.code.gson:gson:2.6.2'
 
     testCompile 'junit:junit:4.12'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -6,10 +6,11 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven { url "https://maven.google.com" }
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha3'
         classpath "com.getkeepsafe.dexcount:dexcount-gradle-plugin:$dexcountVersion"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/integration/gradle/wrapper/gradle-wrapper.properties
+++ b/integration/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountExtensionSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountExtensionSpec.groovy
@@ -63,8 +63,8 @@ final class DexMethodCountExtensionSpec extends Specification {
 
         // Override APK file
         DexMethodCountTask task = project.tasks.getByName("countDebugDexMethods") as DexMethodCountTask
-        task.apkOrDex = Mock(BaseVariantOutput)
-        task.apkOrDex.outputFile >> apkFile
+        task.variantOutputName = "extensionSpec"
+        task.apkOrDexFile = apkFile
         task.execute()
 
         then:
@@ -92,8 +92,8 @@ final class DexMethodCountExtensionSpec extends Specification {
 
         // Override APK file
         DexMethodCountTask task = project.tasks.getByName("countDebugDexMethods") as DexMethodCountTask
-        task.apkOrDex = Mock(BaseVariantOutput)
-        task.apkOrDex.outputFile >> apkFile
+        task.variantOutputName = "extensionSpec"
+        task.apkOrDexFile = apkFile
         task.execute()
 
         then:

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
@@ -183,8 +183,8 @@ final class DexMethodCountPluginSpec extends Specification {
 
     // Override APK file
     DexMethodCountTask task = project.tasks.getByName("countDebugDexMethods") as DexMethodCountTask
-    task.apkOrDex = Mock(BaseVariantOutput)
-    task.apkOrDex.outputFile >> apkFile
+    task.variantOutputName = "pluginSpec"
+    task.apkOrDexFile = apkFile
     task.execute()
 
     then:

--- a/src/test/groovy/com/getkeepsafe/dexcount/InstantRunSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/InstantRunSpec.groovy
@@ -38,8 +38,8 @@ final class InstantRunSpec extends Specification {
         def project = ProjectBuilder.builder().build()
         def task = project.tasks.create('countDexMethods', DexMethodCountTask)
         task.config = new DexMethodCountExtension()
-        task.apkOrDex = Mock(BaseVariantOutput)
-        task.apkOrDex.outputFile >> apkFile
+        task.variantOutputName = "instantRunSpec"
+        task.apkOrDexFile = apkFile
 
         when:
         task.generatePackageTree()


### PR DESCRIPTION
Instead of grabbing variant output from the `assemble` task, we can hook up to the `package` task and depend on that.

The wrinkle is that, in the new tools version, its output is a directory, as opposed to the prior version that yielded a single package file.  The counter task is a little more complicated now, but things seem to work.  Fingers crossed.

Fixes #161