### PR TITLE
Refactor to support renamed variant outputs

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountExtensionSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountExtensionSpec.groovy
@@ -71,9 +71,8 @@ final class DexMethodCountExtensionSpec extends Specification {
         project.evaluate()
 
         // Override APK file
-        DexMethodCountTask task = project.tasks.getByName("countDebugDexMethods") as DexMethodCountTask
+        DexMethodCountTaskBase task = project.tasks.getByName("countDebugDexMethods") as DexMethodCountTaskBase
         task.variantOutputName = "extensionSpec"
-        task.inputFile = null // tests fail using Gradle Plugin 2.3.3 if this remains set
         task.inputDirectory = apkFile.parentFile
         task.execute()
 
@@ -101,9 +100,8 @@ final class DexMethodCountExtensionSpec extends Specification {
         project.evaluate()
 
         // Override APK file
-        DexMethodCountTask task = project.tasks.getByName("countDebugDexMethods") as DexMethodCountTask
+        DexMethodCountTaskBase task = project.tasks.getByName("countDebugDexMethods") as DexMethodCountTaskBase
         task.variantOutputName = "extensionSpec"
-        task.inputFile = null // tests fail using Gradle Plugin 2.3.3 if this remains set
         task.inputDirectory = apkFile.parentFile
         task.execute()
 

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
@@ -196,9 +196,8 @@ final class DexMethodCountPluginSpec extends Specification {
     project.evaluate()
 
     // Override APK file
-    DexMethodCountTask task = project.tasks.getByName("countDebugDexMethods") as DexMethodCountTask
+    DexMethodCountTaskBase task = project.tasks.getByName("countDebugDexMethods") as DexMethodCountTaskBase
     task.variantOutputName = "pluginSpec"
-    task.inputFile = null // tests fail using Gradle Plugin 2.3.3 if this remains set
     task.inputDirectory = apkFile.parentFile
     task.execute()
 


### PR DESCRIPTION
This commit refactors the task into an abstract base and two concrete
implementations, one for AGP 2 and one for AGP 3.  This removes the
dual-optional-input model.  The legacy task is _not_ incremental, and
just holds a reference to the BaseVariantOutput, the way it used to.
The modern task remains incremental.

Fixes #181