### PR TITLE
Fix typo that only Groovy would ever allow

### DIFF
--- a/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
+++ b/src/main/groovy/com/getkeepsafe/dexcount/DexMethodCountPlugin.groovy
@@ -239,7 +239,7 @@ class DexMethodCountPlugin implements Plugin<Project> {
         @Override
         void applyToLibraryVariant(LibraryVariant variant) {
             def packageTask = variant.packageLibrary
-            def dexcountTask = createTask(ModernMethodCountTask, variant, null) { t -> t.inputFile = packageTask.archivePath }
+            def dexcountTask = createTask(ModernMethodCountTask, variant, null) { t -> t.inputDirectory = packageTask.archivePath }
             addDexcountTaskToGraph(packageTask, dexcountTask)
         }
 


### PR DESCRIPTION
We really ought to re-write this plugin in Kotlin.

Fixes #187 