### PR TITLE
[Gradle] - Use versions.gradle to organize dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,19 +15,21 @@
  */
 
 buildscript {
+    apply from: rootProject.file("gradle/versions.gradle")
+
     repositories {
         maven { url "https://plugins.gradle.org/m2/" } // Mirrors jcenter() and mavenCentral()
     }
 
     dependencies {
         // Check for plugin updates
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.12.0"
+        classpath plugs.gradleVersionsPlugin
     }
 }
 
 repositories {
     maven { url "https://plugins.gradle.org/m2/" } // Mirrors jcenter() and mavenCentral()
-    maven { url "https://maven.google.com" }
+    google()
 }
 
 apply plugin: "groovy"
@@ -49,13 +51,13 @@ jar {
 
 dependencies {
     compile gradleApi()
-    compile "com.google.code.gson:gson:2.6.2"
+    compile deps.gson
 
-    compileOnly "com.android.tools.build:gradle:3.0.0-alpha3"
+    compileOnly plugs.gradle
 
-    testCompile "com.android.tools.build:gradle:3.0.0-alpha3"
-    testCompile "junit:junit:4.12"
-    testCompile "org.spockframework:spock-core:1.0-groovy-2.4", { exclude module: "groovy-all" } // Use localGroovy()
+    testCompile plugs.gradle
+    testCompile deps.junit
+    testCompile deps.spockCore, { exclude module: "groovy-all" } // Use localGroovy()
 }
 
 apply from: file("gradle/gradle-mvn-push.gradle")

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,0 +1,40 @@
+// Variables for entire project
+ext {
+  // Setup
+  minSdkVersion = 16
+  targetSdkVersion = 25
+  compileSdkVersion = 25
+  buildToolsVersion = "25.0.2"
+  sourceCompatibilityVersion = JavaVersion.VERSION_1_7
+  targetCompatibilityVersion = JavaVersion.VERSION_1_7
+
+  // Common versions
+  supportLibraryVersion = "25.2.0"
+  kotlinVersion = "1.1.3-2"
+}
+
+// Plugins
+ext.plugs = [
+        "gradle"              : "com.android.tools.build:gradle:3.0.0-alpha3",
+        "kotlinGradlePlugin"  : "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
+        "dexcountGradlePlugin": "com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.7.2",
+        "gradleVersionsPlugin": "com.github.ben-manes:gradle-versions-plugin:0.15.0"
+]
+
+
+// Dependencies
+ext.deps = [
+        // compile
+        "appcompatv7" : "com.android.support:appcompat-v7:$supportLibraryVersion",
+        "kotlinStdlib": "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion",
+        "gson"        : "com.google.code.gson:gson:2.6.2",
+
+        // androidTestCompile
+        "runner"      : "com.android.support.test:runner:0.4.1",
+        "rules"       : "com.android.support.test:rules:0.4.1",
+
+        // testCompile
+        "junit"       : "junit:junit:4.12",
+        "spockCore"   : "org.spockframework:spock-core:1.1-groovy-2.4",
+        "hamcrestCore": "org.hamcrest:hamcrest-core:1.3"
+]

--- a/integration/app/build.gradle
+++ b/integration/app/build.gradle
@@ -2,23 +2,25 @@ apply plugin: "com.android.application"
 apply plugin: "com.getkeepsafe.dexcount"
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     publishNonDefault true
 
     defaultConfig {
         applicationId "com.getkeepsafe.dexcount.integration"
-        minSdkVersion 16
-        targetSdkVersion 25
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
     }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
+
         debug {
             minifyEnabled false
         }
@@ -31,7 +33,7 @@ dexcount {
 }
 
 dependencies {
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    testCompile "junit:junit:4.12"
-    compile "com.android.support:appcompat-v7:25.2.0"
+    compile deps.appcompatv7
+
+    testCompile deps.junit
 }

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -6,9 +6,10 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
-        maven { url "https://maven.google.com" }
+        google()
         jcenter()
     }
+
     dependencies {
         classpath "com.android.tools.build:gradle:3.0.0-alpha3"
         classpath "com.getkeepsafe.dexcount:dexcount-gradle-plugin:$dexcountVersion"

--- a/integration/tests/build.gradle
+++ b/integration/tests/build.gradle
@@ -2,12 +2,12 @@ apply plugin: "com.android.test" // A plugin used for test-only-modules
 apply plugin: "com.getkeepsafe.dexcount"
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 25
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
 
         // The package name of the test app
         testApplicationId "com.getkeepsafe.dexcount.integration.tests"
@@ -26,7 +26,7 @@ android {
 
 dependencies {
     // Android Testing Support Library"s runner and rules and hamcrest matchers
-    compile "com.android.support.test:runner:0.4.1"
-    compile "com.android.support.test:rules:0.4.1"
-    compile "org.hamcrest:hamcrest-core:1.3"
+    compile deps.runner
+    compile deps.rules
+    compile deps.hamcrestCore
 }


### PR DESCRIPTION
@benjamin-bader 
PR: https://github.com/KeepSafe/dexcount-gradle-plugin/pull/193 must be merged first