### PR TITLE
[Logging] - Add color logging back in

### DIFF
--- a/.buildscript/test.sh
+++ b/.buildscript/test.sh
@@ -4,7 +4,7 @@ set -e
 
 # Not sure how well Travis deals with cwd; restore it on script exit.
 DIR=`pwd`
-trap "cd $DIR" SIGINT SIGTERM EXIT 
+trap "cd $DIR" SIGINT SIGTERM EXIT
 
 ./gradlew clean build install
 
@@ -12,8 +12,8 @@ VERSION=`grep '^VERSION_NAME=' gradle.properties | cut -d '=' -f 2`
 
 echo "Building integration test project..."
 cd integration
-./gradlew --stacktrace clean -PdexcountVersion="$VERSION" :app:assembleDebug > app.log
-./gradlew --stacktrace clean -PdexcountVersion="$VERSION" :tests:assembleDebug > tests.log
+./gradlew clean -PdexcountVersion="$VERSION" :app:assembleDebug 2>&1 -s | tee app.log
+./gradlew clean -PdexcountVersion="$VERSION" :tests:assembleDebug 2>&1 -s | tee tests.log
 
 echo "Integration build done!  Running tests..."
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,4 +75,3 @@ afterEvaluate {
     compileGroovy.classpath += files(compileKotlin.destinationDir)
     classes.dependsOn compileGroovy
 }
-


### PR DESCRIPTION
@benjamin-bader 
Closes #127

Basically I am using the re-packaged API and then followed this PR https://github.com/KeepSafe/dexcount-gradle-plugin/pull/126 in order to add it back in.

Example:
<img width="582" alt="screen shot 2017-07-20 at 12 15 48 am" src="https://user-images.githubusercontent.com/1739848/28405072-a1018420-6ce0-11e7-8d6d-b813b4d51674.png">
