### PR TITLE
Bits of Kotlin-related cleanup

### DIFF
--- a/src/main/kotlin/com/getkeepsafe/dexcount/Deobfuscator.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Deobfuscator.kt
@@ -26,10 +26,9 @@ import java.util.TreeMap
  * mapping file.
  */
 open class Deobfuscator(reader: MappingReader?) {
-    private val mapping: MutableMap<String, String>
+    private val mapping = TreeMap<String, String>()
 
     init {
-        mapping = TreeMap<String, String>()
         reader?.pump(Processor())
     }
 

--- a/src/main/kotlin/com/getkeepsafe/dexcount/GradleApi.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/GradleApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 KeepSafe Software
+ * Copyright (C) 2016-2017 KeepSafe Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,64 @@
 
 package com.getkeepsafe.dexcount
 
-import org.codehaus.groovy.runtime.InvokerHelper
 import org.gradle.StartParameter
+import org.gradle.api.Project
 
 /**
- * Attempts to isolate our use bits of the Gradle API that have changed in
- * incompatible ways over time.
+ * Return `true` if Gradle was launched with `--stacktrace`,
+ * otherwise `false`.
+ *
+ * Gradle broke compatibility between 2.13 and 2.14 by repackaging
+ * the `ShowStacktrace` enum; consequently we need to refer to
+ * it by string name only.
  */
-object GradleApi {
-    /**
-     * Return `true` if Gradle was launched with `--stacktrace`,
-     * otherwise `false`.
-     *
-     * Gradle broke compatibility between 2.13 and 2.14 by repackaging
-     * the `ShowStacktrace` enum; consequently we need to refer to
-     * it by string name only.
-     */
-    @JvmStatic fun isShowStacktrace(startParam: StartParameter): Boolean {
-        val stacktrace = InvokerHelper.invokeMethod(startParam, "getShowStacktrace", null) as Enum<*>
+val StartParameter.isShowStacktrace: Boolean
+    get() {
+        val getShowStackTrace = StartParameter::class.java.getMethod("getShowStacktrace").also { it.isAccessible = true }
+        val stacktrace = getShowStackTrace(this) as Enum<*>
         return "INTERNAL_EXCEPTIONS" != stacktrace.name
     }
-}
+
+/**
+ * `true` if this project is compiled with Instant Run support, otherwise `false`.
+ */
+val Project.isInstantRun: Boolean
+    get() {
+        val optionString = properties["android.optional.compilation"] as? String
+        val optionList = optionString?.split(",")?.map(String::trim) ?: emptyList()
+        return optionList.any { it == "INSTANT_DEV" }
+    }
+
+/**
+ * `true` if the current JVM version is 1.8 or above, otherwise `false`.
+ */
+val isAtLeastJavaEight: Boolean
+    get() {
+        var version = System.getProperty("java.version")
+        if (version == null) {
+            // All JVMs provide this property... what's going on?
+            return false
+        }
+
+        // Java version strings are something like 1.8.0_65; we don't
+        // care about the third component, if it exists.  Skip it.
+        val indexOfDecimal = version.indexOf('.').let {
+            if (it != -1) {
+                version.indexOf('.', it + 1)
+            } else {
+                it
+            }
+        }
+
+        if (indexOfDecimal != -1) {
+            version = version.substring(0, indexOfDecimal)
+        }
+
+        return try {
+            val numericVersion = java.lang.Double.parseDouble(version)
+            numericVersion >= 1.8
+        } catch (ignored: NumberFormatException) {
+            // Invalid Java version number; who knows.
+            false
+        }
+    }

--- a/src/main/kotlin/com/getkeepsafe/dexcount/IOUtil.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/IOUtil.kt
@@ -20,17 +20,6 @@ import java.io.File
 import java.io.InputStream
 import java.io.PrintStream
 
-object IOUtil {
-    @JvmStatic fun drainToFile(stream: InputStream, file: File) {
-        stream.use { input ->
-            File(file.path).outputStream().use { output ->
-                input.copyTo(output)
-                output.flush()
-            }
-        }
-    }
-}
-
 fun File.writeFromStream(stream: InputStream) {
     this.outputStream().use { output ->
         stream.copyTo(output)

--- a/src/main/kotlin/com/getkeepsafe/dexcount/PackageTree.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/PackageTree.kt
@@ -52,7 +52,7 @@ class PackageTree(
     // Same semantics as methodTotal_.
     private var fieldTotal_: Int? = null
 
-    private val deobfuscator_: Deobfuscator = deobfuscator ?: Deobfuscator(null)
+    private val deobfuscator_: Deobfuscator = deobfuscator ?: Deobfuscator.empty
     private val children_: SortedMap<String, PackageTree> = TreeMap()
 
     // The set of methods declared on this node.  Will be empty for package

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -16,8 +16,16 @@
 
 package com.getkeepsafe.dexcount
 
-import com.android.build.gradle.*
-import com.android.build.gradle.api.*
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.TestExtension
+import com.android.build.gradle.api.ApkVariant
+import com.android.build.gradle.api.ApkVariantOutput
+import com.android.build.gradle.api.ApplicationVariant
+import com.android.build.gradle.api.BaseVariant
+import com.android.build.gradle.api.BaseVariantOutput
+import com.android.build.gradle.api.LibraryVariant
+import com.android.build.gradle.api.TestVariant
 import com.android.builder.Version
 import com.android.repository.Revision
 import com.getkeepsafe.dexcount.sdkresolver.SdkResolver
@@ -27,44 +35,6 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import java.io.File
 import kotlin.reflect.KClass
-
-val Project.isInstantRun: Boolean
-    get() {
-        val compilationOptionString = project.properties["android.optional.compilation"] as? String ?: ""
-        val compilationOptionList = compilationOptionString.split(",").map(String::trim)
-        return compilationOptionList.any { it == "INSTANT_DEV" }
-    }
-
-val isAtLeastJavaEight: Boolean
-    get() {
-        var version = System.getProperty("java.version")
-        if (version == null) {
-            // All JVMs provide this property... what's going on?
-            return false
-        }
-
-        // Java version strings are something like 1.8.0_65; we don't
-        // care about the third component, if it exists.  Skip it.
-        val indexOfDecimal = version.indexOf('.').let {
-            if (it != -1) {
-                version.indexOf('.', it + 1)
-            } else {
-                it
-            }
-        }
-
-        if (indexOfDecimal != -1) {
-            version = version.substring(0, indexOfDecimal)
-        }
-
-        return try {
-            val numericVersion = java.lang.Double.parseDouble(version)
-            numericVersion >= 1.8
-        } catch (ignored: NumberFormatException) {
-            // Invalid Java version number; who knows.
-            false
-        }
-    }
 
 open class DexMethodCountPlugin: Plugin<Project> {
     companion object {
@@ -107,7 +77,7 @@ abstract class TaskProvider(
         // If the user has passed '--stacktrace' or '--full-stacktrace', assume
         // that they are trying to report a dexcount bug.  Help them help us out
         // by printing the current plugin title and version.
-        if (GradleApi.isShowStacktrace(project.gradle.startParameter)) {
+        if (project.gradle.startParameter.isShowStacktrace) {
             printVersion = true
         }
     }

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexFileSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexFileSpec.groovy
@@ -28,7 +28,7 @@ final class DexFileSpec extends Specification {
         def aarFile = temporaryFolder.newFile("test.aar")
 
         getClass().getResourceAsStream('/android-beacon-library-2.7.aar').withStream { input ->
-            IOUtil.drainToFile(input, aarFile)
+            aarFile.append(input)
         }
 
         when:
@@ -46,7 +46,7 @@ final class DexFileSpec extends Specification {
         def apk = temporaryFolder.newFile("app-debug-tools-v24.apk")
 
         getClass().getResourceAsStream("/app-debug-tools-v24.apk").withStream { input ->
-            IOUtil.drainToFile(input, apk)
+            apk.append(input)
         }
 
         when:

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountExtensionSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountExtensionSpec.groovy
@@ -46,7 +46,7 @@ final class DexMethodCountExtensionSpec extends Specification {
         apkFile = tempFolder.newFile("tiles.apk")
         def apkResource = getClass().getResourceAsStream("/tiles.apk")
         apkResource.withStream { input ->
-            IOUtil.drainToFile(input, apkFile)
+            apkFile.append(input)
         }
     }
 

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
@@ -176,7 +176,7 @@ final class DexMethodCountPluginSpec extends Specification {
     def apkFile = tempFolder.newFile("tiniest-smallest-app.apk")
     def apkResource = getClass().getResourceAsStream("/tiniest-smallest-app.apk")
     apkResource.withStream { input ->
-      IOUtil.drainToFile(input, apkFile)
+        apkFile.append(input)
     }
 
     project.apply plugin: "com.android.application"


### PR DESCRIPTION
- Remove vestiges of Groovy code, especially IOUtil.
- Consolidate Gradle API extensions into GradleApi.kt
- Use `null` less