### PR TITLE
Fix warnings from kotlin

### DIFF
--- a/src/main/kotlin/com/getkeepsafe/dexcount/PackageTree.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/PackageTree.kt
@@ -129,14 +129,9 @@ class PackageTree(
     fun print(out: Appendable, format: OutputFormat, opts: PrintOptions) {
         when (format) {
             OutputFormat.LIST -> printPackageList(out, opts)
-
             OutputFormat.TREE -> printTree(out, opts)
-
             OutputFormat.JSON -> printJson(out, opts)
-
             OutputFormat.YAML -> printYaml(out, opts)
-
-            else -> throw IllegalArgumentException("Unknown format: $format")
         }
     }
 


### PR DESCRIPTION
@benjamin-bader 
Attempting to fix the following:

**Kotlin:**
```
w: /home/travis/build/KeepSafe/dexcount-gradle-plugin/src/main/kotlin/com/getkeepsafe/dexcount/PackageTree.kt: (139, 13): 'when' is exhaustive so 'else' is redundant here
w: /home/travis/build/KeepSafe/dexcount-gradle-plugin/src/main/kotlin/com/getkeepsafe/dexcount/Tasks.kt: (22, 23): 'Nullable' is deprecated. Deprecated in Java
w: /home/travis/build/KeepSafe/dexcount-gradle-plugin/src/main/kotlin/com/getkeepsafe/dexcount/Tasks.kt: (70, 6): 'Nullable' is deprecated. Deprecated in Java
```