### PR TITLE
Replace modern 'InputDirectory' with 'InputFile'

### DIFF
--- a/.buildscript/test.sh
+++ b/.buildscript/test.sh
@@ -13,6 +13,7 @@ VERSION=`grep '^VERSION_NAME=' gradle.properties | cut -d '=' -f 2`
 echo "Building integration test project..."
 cd integration
 ./gradlew clean -PdexcountVersion="$VERSION" :app:assembleDebug 2>&1 --stacktrace | tee app.log
+./gradlew clean -PdexcountVersion="$VERSION" :lib:assembleDebug 2>&1 --stacktrace | tee lib.log
 ./gradlew clean -PdexcountVersion="$VERSION" :tests:assembleDebug 2>&1 --stacktrace | tee tests.log
 
 echo "Integration build done!  Running tests..."
@@ -34,5 +35,12 @@ grep -F 'Total methods in tests-debug.apk: 3086 (4.71% used)' tests.log || die "
 grep -F 'Total fields in tests-debug.apk:  774 (1.18% used)' tests.log || die "Incorrect field count in tests-debug.apk"
 grep -F 'Methods remaining in tests-debug.apk: 62449' tests.log || die "Incorrect remaining-method value in tests-debug.apk"
 grep -F 'Fields remaining in tests-debug.apk:  64761' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
+
+grep -F 'Total methods in lib-debug.aar: 7 (0.01% used)' lib.log || die "Incorrect method count in lib-debug.aar"
+grep -F 'Total fields in lib-debug.aar:  6 (0.01% used)' lib.log || die "Incorrect field count in lib-debug.aar"
+grep -F 'Total classes in lib-debug.aar:  5 (0.01% used)' lib.log || die "Incorrect class count in lib-debug.aar"
+grep -F 'Methods remaining in lib-debug.aar: 65528' lib.log || die "Incorrect remaining-method count in lib-debug.aar"
+grep -F 'Fields remaining in lib-debug.aar:  65529' lib.log || die "Incorrect remaining-field count in lib-debug.aar"
+grep -F 'Classes remaining in lib-debug.aar:  65530' lib.log || die "Incorrect remaining-class count in lib-debug.aar"
 
 echo "Tests complete."

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -9,12 +9,12 @@ ext {
     targetCompatibilityVersion = JavaVersion.VERSION_1_7
 
     // Common versions
-    kotlinVersion = "1.1.3-2"
+    kotlinVersion = "1.1.4-3"
 }
 
 // Plugins
 ext.plugs = [
-        "gradle"              : "com.android.tools.build:gradle:3.0.0-alpha3",
+        "gradle"              : "com.android.tools.build:gradle:3.0.0-beta6",
         "kotlinGradlePlugin"  : "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
         "gradleVersionsPlugin": "com.github.ben-manes:gradle-versions-plugin:0.15.0"
 ]

--- a/integration/gradle/wrapper/gradle-wrapper.properties
+++ b/integration/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/integration/lib/build.gradle
+++ b/integration/lib/build.gradle
@@ -1,0 +1,38 @@
+apply plugin: "com.android.library"
+apply plugin: "com.getkeepsafe.dexcount"
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
+    publishNonDefault true
+
+    defaultConfig {
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        debug {
+            minifyEnabled false
+        }
+
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+}
+
+dexcount {
+    verbose = true
+    teamCitySlug = project.name
+}
+
+dependencies {
+    compile deps.appcompatv7
+
+    testCompile deps.junit
+}

--- a/integration/lib/src/main/AndroidManifest.xml
+++ b/integration/lib/src/main/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.getkeepsafe.dexcount.integration"
+          xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application />
+
+</manifest>

--- a/integration/lib/src/main/java/com/getkeepsafe/dexcount/integration/Lib.java
+++ b/integration/lib/src/main/java/com/getkeepsafe/dexcount/integration/Lib.java
@@ -1,0 +1,8 @@
+package com.getkeepsafe.dexcount.integration;
+
+public class Lib {
+    public static void foo() {
+        android.util.Log.d("Lib", "I'm in an AAR!");
+    }
+}
+

--- a/integration/settings.gradle
+++ b/integration/settings.gradle
@@ -1,2 +1,3 @@
 include ":app"
+include ":lib"
 include ":tests"

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -201,7 +201,7 @@ class ThreeOhProvider(project: Project): TaskProvider(project) {
 
     override fun applyToLibraryVariant(variant: LibraryVariant) {
         val packageTask = variant.packageLibrary
-        val dexcountTask = createTask(ModernMethodCountTask::class, variant, null) { t -> t.inputDirectory = packageTask.archivePath }
+        val dexcountTask = createTask(ModernMethodCountTask::class, variant, null) { t -> t.inputFile = packageTask.archivePath }
         addDexcountTaskToGraph(packageTask, dexcountTask)
     }
 
@@ -209,8 +209,7 @@ class ThreeOhProvider(project: Project): TaskProvider(project) {
         variant.outputs.all { output ->
             if (output is ApkVariantOutput) {
                 // why wouldn't it be?
-                val packageDirectory = output.packageApplication.outputDirectory
-                val task = createTask(ModernMethodCountTask::class, variant, output) { t -> t.inputDirectory = packageDirectory }
+                val task = createTask(ModernMethodCountTask::class, variant, output) { t -> t.inputFile = output.outputFile }
                 addDexcountTaskToGraph(output.packageApplication, task)
             } else {
                 throw IllegalArgumentException("Unexpected output type for variant ${variant.name}: ${output::class.java}")

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Tasks.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Tasks.kt
@@ -21,8 +21,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Nullable
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.ParallelizableTask
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
@@ -32,26 +31,30 @@ import java.io.File
  */
 const val MAX_DEX_REFS: Int = 0xFFFF // 65535
 
-@ParallelizableTask
 open class ModernMethodCountTask: DexMethodCountTaskBase() {
     /**
-     * The output directory of the 'package' task; will contain an
-     * APK or an AAR.
+     * The output of the 'package' task; will be either an APK or an AAR.
      */
-    @InputDirectory
-    lateinit var inputDirectory: File
+    @InputFile
+    lateinit var inputFile: File
 
     override val fileToCount: File?
-        get() = inputDirectory.listFiles { _, name ->
-            name?.endsWith(".apk") ?: false
-        }.firstOrNull()
+        get() = inputFile
 
     override val rawInputRepresentation: String
-        get() = "$inputDirectory"
+        get() = "$inputFile"
 }
 
-@ParallelizableTask
 open class LegacyMethodCountTask: DexMethodCountTaskBase() {
+
+    /**
+     * The output of the 'assemble' task, on AGP < 3.0.  Its 'outputFile'
+     * property will point to either an AAR or an APK.
+     *
+     * We don't use [@Input][org.gradle.api.tasks.Input] here because
+     * [BaseVariantOutput] implementations aren't is [Serializable].  This
+     * makes Gradle's input cache routines crash, sometimes.
+     */
 
     lateinit var variantOutput: BaseVariantOutput
 

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountExtensionSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountExtensionSpec.groovy
@@ -72,7 +72,7 @@ final class DexMethodCountExtensionSpec extends Specification {
         // Override APK file
         DexMethodCountTaskBase task = project.tasks.getByName("countDebugDexMethods") as DexMethodCountTaskBase
         task.variantOutputName = "extensionSpec"
-        task.inputDirectory = apkFile.parentFile
+        task.inputFile = apkFile
         task.execute()
 
         then:
@@ -101,7 +101,7 @@ final class DexMethodCountExtensionSpec extends Specification {
         // Override APK file
         DexMethodCountTaskBase task = project.tasks.getByName("countDebugDexMethods") as DexMethodCountTaskBase
         task.variantOutputName = "extensionSpec"
-        task.inputDirectory = apkFile.parentFile
+        task.inputFile = apkFile
         task.execute()
 
         then:

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
@@ -196,7 +196,7 @@ final class DexMethodCountPluginSpec extends Specification {
     // Override APK file
     DexMethodCountTaskBase task = project.tasks.getByName("countDebugDexMethods") as DexMethodCountTaskBase
     task.variantOutputName = "pluginSpec"
-    task.inputDirectory = apkFile.parentFile
+    task.inputFile = apkFile
     task.execute()
 
     then:


### PR DESCRIPTION
Somewhere between Android Studio 3.0 alpha1 and beta6, the AGP API
changed in a few ways.  Notably, the `outputFile` property of variant
outputs is now properly implemented, and the PackageLibraryTask's
archive path now points to an AAR, and not a folder.

We account for both of those changes by updating the modern task such
that it accepts an input file, and not an input directory.

Fixes #217