### PR TITLE
Fix renaming build output file name after initialize plugin

### DIFF
--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -238,7 +238,9 @@ class ThreeOhProvider(project: Project): TaskProvider(project) {
 
     override fun applyToLibraryVariant(variant: LibraryVariant) {
         val packageTask = variant.packageLibrary
-        val dexcountTask = createTask(ModernMethodCountTask::class, variant, null) { t -> t.inputFile = packageTask.archivePath }
+        val dexcountTask = createTask(ModernMethodCountTask::class, variant, null) { t ->
+            t.inputFileProvider = { packageTask.archivePath }
+        }
         addDexcountTaskToGraph(packageTask, dexcountTask)
     }
 
@@ -246,7 +248,9 @@ class ThreeOhProvider(project: Project): TaskProvider(project) {
         variant.outputs.all { output ->
             if (output is ApkVariantOutput) {
                 // why wouldn't it be?
-                val task = createTask(ModernMethodCountTask::class, variant, output) { t -> t.inputFile = output.outputFile }
+                val task = createTask(ModernMethodCountTask::class, variant, output) { t ->
+                    t.inputFileProvider = { output.outputFile }
+                }
                 addDexcountTaskToGraph(output.packageApplication, task)
             } else {
                 throw IllegalArgumentException("Unexpected output type for variant ${variant.name}: ${output::class.java}")

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Tasks.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Tasks.kt
@@ -32,17 +32,22 @@ import javax.annotation.Nullable
 const val MAX_DEX_REFS: Int = 0xFFFF // 65535
 
 open class ModernMethodCountTask: DexMethodCountTaskBase() {
+
+    lateinit var inputFileProvider: () -> File
+
     /**
      * The output of the 'package' task; will be either an APK or an AAR.
      */
     @InputFile
-    lateinit var inputFile: File
+    fun getInputFile(): File {
+        return inputFileProvider()
+    }
 
     override val fileToCount: File?
-        get() = inputFile
+        get() = getInputFile()
 
     override val rawInputRepresentation: String
-        get() = "$inputFile"
+        get() = "${getInputFile()}"
 }
 
 open class LegacyMethodCountTask: DexMethodCountTaskBase() {

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountExtensionSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountExtensionSpec.groovy
@@ -73,7 +73,7 @@ final class DexMethodCountExtensionSpec extends Specification {
         DexMethodCountTaskBase task = project.tasks.getByName(
             "countDebugDexMethods") as DexMethodCountTaskBase
         task.variantOutputName = "extensionSpec"
-        task.inputFile = apkFile
+        task.inputFileProvider = {apkFile}
         task.execute()
 
         then:
@@ -103,7 +103,7 @@ final class DexMethodCountExtensionSpec extends Specification {
         DexMethodCountTaskBase task = project.tasks.getByName(
             "countDebugDexMethods") as DexMethodCountTaskBase
         task.variantOutputName = "extensionSpec"
-        task.inputFile = apkFile
+        task.inputFileProvider = {apkFile}
         task.execute()
 
         then:

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
@@ -198,7 +198,7 @@ final class DexMethodCountPluginSpec extends Specification {
         DexMethodCountTaskBase task = project.tasks.getByName(
             "countDebugDexMethods") as DexMethodCountTaskBase
         task.variantOutputName = "pluginSpec"
-        task.inputFile = apkFile
+        task.inputFileProvider = {apkFile}
         task.execute()
 
         then:


### PR DESCRIPTION
Hello. 
I try to fix this issue:
https://github.com/KeepSafe/dexcount-gradle-plugin/issues/220

In my project it works. But I not sure for all projects. 