### PR TITLE
fix: Support Dex file format version 038

### DIFF
--- a/src/main/java/com/android/dexdeps/DexData.java
+++ b/src/main/java/com/android/dexdeps/DexData.java
@@ -69,7 +69,8 @@ public class DexData {
      */
     private static boolean verifyMagic(byte[] magic) {
         return Arrays.equals(magic, HeaderItem.DEX_FILE_MAGIC_v035) ||
-            Arrays.equals(magic, HeaderItem.DEX_FILE_MAGIC_v037);
+            Arrays.equals(magic, HeaderItem.DEX_FILE_MAGIC_v037) ||
+            Arrays.equals(magic, HeaderItem.DEX_FILE_MAGIC_v038);
     }
 
     /**
@@ -588,6 +589,11 @@ public class DexData {
         // V037 was introduced in API LEVEL 24
         public static final byte[] DEX_FILE_MAGIC_v037 =
             "dex\n037\0".getBytes(StandardCharsets.US_ASCII);
+
+        // V038 was introduced in API LEVEL 26
+        public static final byte[] DEX_FILE_MAGIC_v038 =
+            "dex\n038\0".getBytes(StandardCharsets.US_ASCII);
+
         public static final int ENDIAN_CONSTANT = 0x12345678;
         public static final int REVERSE_ENDIAN_CONSTANT = 0x78563412;
     }


### PR DESCRIPTION
Android 8 added another Dex file format version - 038. This fixes the plugin so that an internal check recognises this value as a valid Dex file.

This was tested by running `test.sh` with the integration project's `minSdkVersion` set at 27, with and without the fix.

Fixes #247 