### PR TITLE
Initial config for plugins.gradle.org

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,7 @@ you through it.  It won't do anyone outside of KeepSafe any good, but the workfl
 is representative of just about any project deploying via Sonatype.
 
 We currently deploy to both Maven Central (via Sonatype's OSS Nexus instance) and to
-plugins.gradle.org.  The latter requires
+plugins.gradle.org.
 
 ### Prerequisites
 
@@ -78,7 +78,7 @@ plugins.gradle.org.  The latter requires
 1. Edit gradle.properties, bump the version number and add '-SNAPSHOT'
 1. Make a *signed* commit:
    ```bash
-   git commit -s -m "Prepare next development version"
+   git commit -S -m "Prepare next development version"
    ```
 1. Push all of our work to Github to make it official:
    ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,86 @@
+How To Release
+==============
+
+Due to Maven Central's very particular requirements, the release process is a bit
+elaborate and requires a good deal of local configuration.  This guide should walk
+you through it.  It won't do anyone outside of KeepSafe any good, but the workflow
+is representative of just about any project deploying via Sonatype.
+
+We currently deploy to both Maven Central (via Sonatype's OSS Nexus instance) and to
+plugins.gradle.org.  The latter requires
+
+### Prerequisites
+
+1. A *published* GPG code-signing key
+1. A Sonatype Nexus OSS account with permission to publish in com.getkeepsafe
+1. A plugins.gradle.org account with permission to publish in com.getkeepsafe
+1. Permission to push directly to https://github.com/KeepSafe/dexcount-gradle-plugin
+
+### Setup
+
+1. Add your GPG key to your github profile - this is required
+   for github to know that your commits and tags are "verified".
+1. Configure your code-signing key in ~/.gradle.properties:
+   ```gradle
+   signing.keyId=<key ID of your GPG signing key>
+   signing.password=<your key's passphrase>
+   signing.secretKeyRingFile=/path/to/your/secring.gpg
+   ```
+1. Configure your Sonatype credentials in ~/.gradle.properties:
+   ```gradle
+   SONATYPE_NEXUS_USERNAME=<nexus username>
+   SONATYPE_NEXUS_PASSWORD=<nexus password>
+   ```
+1. Configure git with your codesigning key; make sure it's the same as the one
+   you use to sign binaries (i.e. it's the same one you added to gradle.properties):
+   ```bash
+   # Do this for the dexcount repo only
+   git config user.email "your@email.com"
+   git config user.signingKey "your-key-id"
+   ```
+1. Add your plugins.gradle.org credentials to ~/.gradle/gradle.properties:
+   ```gradle
+   gradle.publish.key=<the key>
+   gradle.publish.secret=<the secret>
+   ```
+
+### Pushing a build
+
+1. Edit gradle.properties, remove '-SNAPSHOT' from the VERSION property
+1. Edit readme so that Gradle examples point to the new version
+1. Edit changelog, add relevant changes, note the date and new version (follow the existing pattern)
+1. Verify that the everything works:
+   ```bash
+   ./gradlew clean check
+   ```
+1. Make a *signed* commit:
+   ```bash
+   git commit -S -m "Release version X.Y.Z"
+   ``` 
+1. Make a *signed* tag ()check existing tags for message format):
+   ```bash
+   git tag -s -a X.Y.Z
+   ```
+1. Upload binaries to Sonatype:
+   ```bash
+   ./gradlew uploadArchives
+   ```
+1. Go to oss.sonatype.org, log in with your credentials
+1. Click "Staging Repositories"
+1. Find the "comgetkeepsafe" repo, usually at the bottom of the list
+1. "Close" the repository (select it then click the "close" button up top), the text field doesn't matter so put whatever you want in it
+1. Wait until that's done
+1. "Release" the repository, leave the checkbox checked.  Hooray, we're in Maven Central now!
+1. Upload binaries to Gradle's plugin portal:
+   ```bash
+   ./gradlew publishPlugins
+   ```
+1. Edit gradle.properties, bump the version number and add '-SNAPSHOT'
+1. Make a *signed* commit:
+   ```bash
+   git commit -s -m "Prepare next development version"
+   ```
+1. Push all of our work to Github to make it official:
+   ```bash
+   git push --tags origin master
+   ```

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ buildscript {
     }
 }
 
+plugins {
+    id "com.gradle.plugin-publish" version "0.10.0"
+}
+
 allprojects {
     repositories {
         mavenLocal()
@@ -77,6 +81,7 @@ dependencies {
 
 apply from: "gradle/gradle-mvn-push.gradle"
 apply from: "gradle/compile.gradle"
+apply from: "gradle/gradle-plugin-portal.gradle"
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
     kotlinOptions {

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -80,7 +80,7 @@ afterEvaluate { project ->
     }
 
     signing {
-        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+        required { isReleaseBuild() && (gradle.taskGraph.hasTask("uploadArchives") || gradle.taskGraph.hasTask("publishPlugins")) }
         sign configurations.archives
     }
 

--- a/gradle/gradle-plugin-portal.gradle
+++ b/gradle/gradle-plugin-portal.gradle
@@ -1,0 +1,19 @@
+pluginBundle {
+    website = POM_URL
+    vcsUrl = POM_SCM_URL
+    description = POM_DESCRIPTION
+    tags = ['android', 'dex', 'method count']
+
+    plugins {
+        dexcount {
+            id = "com.getkeepsafe.dexcount"
+            displayName = POM_NAME
+        }
+    }
+
+    mavenCoordinates {
+        groupId = GROUP
+        artifactId = POM_ARTIFACT_ID
+        version = VERSION_NAME
+    }
+}


### PR DESCRIPTION
This is broken in that a simple `./gradlew publishPlugins` doesn't do everything it needs to - we need to make gradle sign the binaries separately.  We'll fix that later.