### PR TITLE
Avoid using deprecated ApkVariant methods in AGP 3.3+

### DIFF
--- a/.buildscript/test.sh
+++ b/.buildscript/test.sh
@@ -23,23 +23,23 @@ function die() {
   exit 1
 }
 
-grep -F 'Total methods in app-debug.apk: 17375 (26.51% used)' app.log || die "Incorrect method count in app-debug.apk"
-grep -F 'Total fields in app-debug.apk:  7961 (12.15% used)' app.log || die "Incorrect field count in app-debug.apk"
-grep -F 'Total classes in app-debug.apk:  2043 (3.12% used)' app.log || die "Incorrect field count in app-debug.apk"
-grep -F 'Methods remaining in app-debug.apk: 48160' app.log || die "Incorrect remaining-method value in app-debug.apk"
-grep -F 'Fields remaining in app-debug.apk:  57574' app.log || die "Incorrect remaining-field value in app-debug.apk"
-grep -F 'Classes remaining in app-debug.apk:  63492' app.log || die "Incorrect remaining-field value in app-debug.apk"
+grep -F 'Total methods in app-debug.apk: 15117 (23.07% used)' app.log || die "Incorrect method count in app-debug.apk"
+grep -F 'Total fields in app-debug.apk:  10120 (15.44% used)' app.log || die "Incorrect field count in app-debug.apk"
+grep -F 'Total classes in app-debug.apk:  1761 (2.69% used)' app.log || die "Incorrect field count in app-debug.apk"
+grep -F 'Methods remaining in app-debug.apk: 50418' app.log || die "Incorrect remaining-method value in app-debug.apk"
+grep -F 'Fields remaining in app-debug.apk:  55415' app.log || die "Incorrect remaining-field value in app-debug.apk"
+grep -F 'Classes remaining in app-debug.apk:  63774' app.log || die "Incorrect remaining-field value in app-debug.apk"
 
-grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_ClassCount' value='2043']" app.log || die "Missing or incorrect Teamcity method count value"
-grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_MethodCount' value='17375']" app.log || die "Missing or incorrect Teamcity method count value"
-grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_FieldCount' value='7961']" app.log || die "Missing or incorrect Teamcity field count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_ClassCount' value='1761']" app.log || die "Missing or incorrect Teamcity method count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_MethodCount' value='15117']" app.log || die "Missing or incorrect Teamcity method count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_FieldCount' value='10120']" app.log || die "Missing or incorrect Teamcity field count value"
 
-grep -F 'Total methods in tests-debug.apk: 3086 (4.71% used)' tests.log || die "Incorrect method count in tests-debug.apk"
-grep -F 'Total fields in tests-debug.apk:  774 (1.18% used)' tests.log || die "Incorrect field count in tests-debug.apk"
-grep -F 'Total classes in tests-debug.apk:  582 (0.89% used)' tests.log || die "Incorrect field count in tests-debug.apk"
-grep -F 'Methods remaining in tests-debug.apk: 62449' tests.log || die "Incorrect remaining-method value in tests-debug.apk"
-grep -F 'Fields remaining in tests-debug.apk:  64761' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
-grep -F 'Classes remaining in tests-debug.apk:  64953' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
+grep -F 'Total methods in tests-debug.apk: 4365 (6.66% used)' tests.log || die "Incorrect method count in tests-debug.apk"
+grep -F 'Total fields in tests-debug.apk:  1275 (1.95% used)' tests.log || die "Incorrect field count in tests-debug.apk"
+grep -F 'Total classes in tests-debug.apk:  723 (1.10% used)' tests.log || die "Incorrect field count in tests-debug.apk"
+grep -F 'Methods remaining in tests-debug.apk: 61170' tests.log || die "Incorrect remaining-method value in tests-debug.apk"
+grep -F 'Fields remaining in tests-debug.apk:  64260' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
+grep -F 'Classes remaining in tests-debug.apk:  64812' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
 
 grep -F 'Total methods in lib-debug.aar: 7 (0.01% used)' lib.log || die "Incorrect method count in lib-debug.aar"
 grep -F 'Total fields in lib-debug.aar:  6 (0.01% used)' lib.log || die "Incorrect field count in lib-debug.aar"

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ buildscript {
 
     repositories {
         gradlePluginPortal()
+        google()
     }
 
     dependencies {
@@ -85,6 +86,9 @@ apply from: "gradle/gradle-plugin-portal.gradle"
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
     kotlinOptions {
-        allWarningsAsErrors = true
+        // Disabling until there's some workaround for the warning
+        // about AGP's builder.jar containing its own bundled Kotlin
+        // runtime library.
+        allWarningsAsErrors = false
     }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,22 +1,21 @@
 // Variables for entire project
 ext {
     minSdkVersion = 19
-    targetSdkVersion = 27
-    compileSdkVersion = 27
-    buildToolsVersion = "27.0.3"
+    targetSdkVersion = 28
+    compileSdkVersion = 28
     javaVersion = "1.7"
-    kotlinVersion = "1.2.50"
+    kotlinVersion = "1.3.11"
 }
 
 ext.deps = [
     // Plugins
     "gradle"              : [
-        dependencies.create("com.android.tools.build:gradle:3.2.0-alpha18") {
+        dependencies.create("com.android.tools.build:gradle:3.3.0-rc03") {
             // Android build tools (as of 3.2.0-alpha18) bundle the deprecated
             // 'jre' stdlib modules, which cause warnings at build-time that
             // fail the build.
-            exclude module: 'kotlin-stdlib-jre7'
-            exclude module: 'kotlin-stdlib-jre8'
+            exclude module: 'kotlin-stdlib-jdk7'
+            exclude module: 'kotlin-stdlib-jdk8'
         }
     ],
     "kotlinGradlePlugin"  : "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
@@ -32,8 +31,14 @@ ext.deps = [
     "spockCore"           : "org.spockframework:spock-core:1.1-groovy-2.4",
 
     // integration - if you change these, you need to update the values in ./.buildscript/test.sh
-    "appcompatv7"         : "com.android.support:appcompat-v7:25.2.0",
-    "runner"              : "com.android.support.test:runner:0.4.1",
-    "rules"               : "com.android.support.test:rules:0.4.1",
+    "appcompatv7"         : ["com.android.support:appcompat-v7:28.0.0"],
+    "droidTest"           : [
+            dependencies.create("com.android.support.test:runner:1.0.2") {
+                exclude module: 'support-annotations'
+            },
+            dependencies.create("com.android.support.test:rules:1.0.2") {
+                exclude module: 'support-annotations'
+            }
+    ],
     "hamcrestCore"        : "org.hamcrest:hamcrest-core:1.3"
 ]

--- a/integration/app/build.gradle
+++ b/integration/app/build.gradle
@@ -3,7 +3,6 @@ apply plugin: "com.getkeepsafe.dexcount"
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     publishNonDefault true
 

--- a/integration/lib/build.gradle
+++ b/integration/lib/build.gradle
@@ -3,7 +3,6 @@ apply plugin: "com.getkeepsafe.dexcount"
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     publishNonDefault true
 

--- a/integration/tests/build.gradle
+++ b/integration/tests/build.gradle
@@ -3,7 +3,6 @@ apply plugin: "com.getkeepsafe.dexcount"
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
@@ -25,7 +24,6 @@ android {
 
 dependencies {
     // Android Testing Support Library"s runner and rules and hamcrest matchers
-    compile deps.runner
-    compile deps.rules
+    compile deps.droidTest
     compile deps.hamcrestCore
 }


### PR DESCRIPTION
The main change here is the addition of the 'ThreeThreeProvider' class, which configures the method-count tasks in the presence of AGP 3.3+.  All the rest of the changes account for build errors due to updating to AGP 3.3, and the changes entailed by fixing those errors.

Fixes #259