### PR TITLE
Count declared methods and fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ dexcount {
     teamCitySlug = null
     runOnEachPackage = true
     maxMethodCount = 64000
+    printDeclarations = true
     enabled = true
 }
 ```
@@ -142,6 +143,7 @@ Each flag controls some aspect of the printed output:
 - `teamCitySlug`: A string which, if specified, will be added to TeamCity stat names.  Null by default.
 - `runOnEachPackage`: When false, does not run count method during package task. True by default.  Synonym for `runOnEachAssemble`, which is deprecated.
 - `maxMethodCount`: When set, the build will fail when the APK/AAR has more methods than the max. 0 by default.
+- `printDeclarations`: When true, prints the declared method and field count. Only allowed in library modules. False by default.
 - `enabled`: When false, no build outputs will be counted.  Defaults to true.
 
 ## Use with Jenkins Plot Plugin

--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ task createClasspathManifest() {
 dependencies {
     implementation deps.kotlinStdlib
     implementation deps.gson
+    implementation deps.javassist
 
     compileOnly deps.gradle
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,5 +40,6 @@ ext.deps = [
                 exclude module: 'support-annotations'
             }
     ],
-    "hamcrestCore"        : "org.hamcrest:hamcrest-core:1.3"
+    "hamcrestCore"        : "org.hamcrest:hamcrest-core:1.3",
+    "javassist"           : "org.javassist:javassist:3.25.0-GA"
 ]

--- a/integration/java-app/build.gradle
+++ b/integration/java-app/build.gradle
@@ -1,0 +1,10 @@
+apply plugin: "java"
+apply plugin: "com.getkeepsafe.dexcount"
+
+dexcount {
+    printDeclarations = true
+}
+
+dependencies {
+    testCompile deps.junit
+}

--- a/integration/java-app/src/main/java/com/getkeepsafe/dexcount/integration/SomeClass.java
+++ b/integration/java-app/src/main/java/com/getkeepsafe/dexcount/integration/SomeClass.java
@@ -1,0 +1,9 @@
+package com.getkeepsafe.dexcount.integration;
+
+public class SomeClass {
+    public final int value;
+
+    public SomeClass(int value) {
+        this.value = value;
+    }
+}

--- a/integration/java-app/src/test/java/com/getkeepsafe/dexcount/integration/ExampleUnitTest.java
+++ b/integration/java-app/src/test/java/com/getkeepsafe/dexcount/integration/ExampleUnitTest.java
@@ -1,0 +1,15 @@
+package com.getkeepsafe.dexcount.integration;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * To work on unit tests, switch the Test Artifact in the Build Variants view.
+ */
+public class ExampleUnitTest {
+    @Test
+    public void addition_isCorrect() throws Exception {
+        assertEquals(new SomeClass(5).value, 5);
+    }
+}

--- a/integration/java-library/build.gradle
+++ b/integration/java-library/build.gradle
@@ -1,0 +1,10 @@
+apply plugin: "java-library"
+apply plugin: "com.getkeepsafe.dexcount"
+
+dexcount {
+    printDeclarations = true
+}
+
+dependencies {
+    testCompile deps.junit
+}

--- a/integration/java-library/src/main/java/com/getkeepsafe/dexcount/integration/SomeClass.java
+++ b/integration/java-library/src/main/java/com/getkeepsafe/dexcount/integration/SomeClass.java
@@ -1,0 +1,9 @@
+package com.getkeepsafe.dexcount.integration;
+
+public class SomeClass {
+    public final int value;
+
+    public SomeClass(int value) {
+        this.value = value;
+    }
+}

--- a/integration/java-library/src/test/java/com/getkeepsafe/dexcount/integration/ExampleUnitTest.java
+++ b/integration/java-library/src/test/java/com/getkeepsafe/dexcount/integration/ExampleUnitTest.java
@@ -1,0 +1,15 @@
+package com.getkeepsafe.dexcount.integration;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * To work on unit tests, switch the Test Artifact in the Build Variants view.
+ */
+public class ExampleUnitTest {
+    @Test
+    public void addition_isCorrect() throws Exception {
+        assertEquals(new SomeClass(5).value, 5);
+    }
+}

--- a/integration/settings.gradle
+++ b/integration/settings.gradle
@@ -1,3 +1,5 @@
 include ":app"
+include ":java-app"
+include ":java-library"
 include ":lib"
 include ":tests"

--- a/src/main/kotlin/com/getkeepsafe/dexcount/DexMethodCountExtension.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/DexMethodCountExtension.kt
@@ -122,6 +122,13 @@ open class DexMethodCountExtension {
     var dxTimeoutSec = 60
 
     /**
+     * When true, then the plugin only counts the declared methods and fields inside this module.
+     * This does NOT represent the actual reference method count, because method references are
+     * ignored. This flag is false by default and can only be turned on for library modules.
+     */
+    var printDeclarations = false
+
+    /**
      * When true, the plugin is enabled and will be run as normal.  When false,
      * the plugin is disabled and will not be run.
      */

--- a/src/main/kotlin/com/getkeepsafe/dexcount/PackageTree.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/PackageTree.kt
@@ -132,7 +132,9 @@ class PackageTree(
         val sb = StringBuilder(64)
 
         if (opts.includeTotalMethodCount) {
-            out.appendln("Total methods: $methodCount")
+            if (opts.isAndroidProject) {
+                out.appendln("Total methods: $methodCount")
+            }
 
             if (opts.printDeclarations) {
                 out.appendln("Total declared methods: $methodCountDeclared")
@@ -151,12 +153,14 @@ class PackageTree(
             out.append(String.format("%-8s ", "classes"))
         }
 
-        if (opts.includeMethodCount) {
-            out.append(String.format("%-8s ", "methods"))
-        }
+        if (opts.isAndroidProject) {
+            if (opts.includeMethodCount) {
+                out.append(String.format("%-8s ", "methods"))
+            }
 
-        if (opts.includeFieldCount) {
-            out.append(String.format("%-8s ", "fields"))
+            if (opts.includeFieldCount) {
+                out.append(String.format("%-8s ", "fields"))
+            }
         }
 
         if (opts.printDeclarations) {
@@ -184,12 +188,14 @@ class PackageTree(
                 out.append(String.format("%-8d ", classCount))
             }
 
-            if (opts.includeMethodCount) {
-                out.append(String.format("%-8d ", methodCount))
-            }
+            if (opts.isAndroidProject) {
+                if (opts.includeMethodCount) {
+                    out.append(String.format("%-8d ", methodCount))
+                }
 
-            if (opts.includeFieldCount) {
-                out.append(String.format("%-8d ", fieldCount))
+                if (opts.includeFieldCount) {
+                    out.append(String.format("%-8d ", fieldCount))
+                }
             }
 
             if (opts.printDeclarations) {
@@ -232,20 +238,22 @@ class PackageTree(
                 appended = true
             }
 
-            if (opts.includeMethodCount) {
-                if (appended) {
-                    out.append(", ")
+            if (opts.isAndroidProject) {
+                if (opts.includeMethodCount) {
+                    if (appended) {
+                        out.append(", ")
+                    }
+                    out.append("$methodCount ${pluralizedMethods(methodCount)}")
+                    appended = true
                 }
-                out.append("$methodCount ${pluralizedMethods(methodCount)}")
-                appended = true
-            }
 
-            if (opts.includeFieldCount) {
-                if (appended) {
-                    out.append(", ")
+                if (opts.includeFieldCount) {
+                    if (appended) {
+                        out.append(", ")
+                    }
+                    out.append("$fieldCount ${pluralizedFields(fieldCount)}")
+                    appended = true
                 }
-                out.append("$fieldCount ${pluralizedFields(fieldCount)}")
-                appended = true
             }
 
             if (opts.printDeclarations) {
@@ -300,12 +308,14 @@ class PackageTree(
             json.name("classes").value(classCount)
         }
 
-        if (opts.includeMethodCount) {
-            json.name("methods").value(methodCount)
-        }
+        if (opts.isAndroidProject) {
+            if (opts.includeMethodCount) {
+                json.name("methods").value(methodCount)
+            }
 
-        if (opts.includeFieldCount) {
-            json.name("fields").value(fieldCount)
+            if (opts.includeFieldCount) {
+                json.name("fields").value(fieldCount)
+            }
         }
 
         if (opts.printDeclarations) {
@@ -330,12 +340,14 @@ class PackageTree(
             out.append("classes: $classCount\n")
         }
 
-        if (opts.includeMethodCount) {
-            out.append("methods: $methodCount\n")
-        }
+        if (opts.isAndroidProject) {
+            if (opts.includeMethodCount) {
+                out.append("methods: $methodCount\n")
+            }
 
-        if (opts.includeFieldCount) {
-            out.append("fields: $fieldCount\n")
+            if (opts.includeFieldCount) {
+                out.append("fields: $fieldCount\n")
+            }
         }
 
         if (opts.printDeclarations) {

--- a/src/main/kotlin/com/getkeepsafe/dexcount/PackageTree.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/PackageTree.kt
@@ -20,10 +20,13 @@ import com.android.dexdeps.FieldRef
 import com.android.dexdeps.HasDeclaringClass
 import com.android.dexdeps.MethodRef
 import com.android.dexdeps.Output
+import com.getkeepsafe.dexcount.PackageTree.Type.DECLARED
+import com.getkeepsafe.dexcount.PackageTree.Type.REFERENCED
 import com.google.gson.stream.JsonWriter
 import java.io.Writer
 import java.nio.CharBuffer
 import java.util.*
+import kotlin.collections.HashSet
 
 class PackageTree(
         private val name_: String,
@@ -42,54 +45,36 @@ class PackageTree(
 
     // A cached sum of classes.
     // Set by `getClassCount()`, and invalidated by adding new nodes.
-    private var classTotal_: Int? = null
+    private var classTotal_ = mutableMapOf<Type, Int>()
 
     // A cached sum of this node and all children's method ref counts.
     // Set by `getMethodCount()`, and invalidated by adding new nodes.
-    private var methodTotal_: Int? = null
+    private var methodTotal_ = mutableMapOf<Type, Int>()
 
     // A cached sum of this node and all children's field-ref counts.
     // Same semantics as methodTotal_.
-    private var fieldTotal_: Int? = null
+    private var fieldTotal_ = mutableMapOf<Type, Int>()
 
     private val deobfuscator_: Deobfuscator = deobfuscator ?: Deobfuscator.empty
     private val children_: SortedMap<String, PackageTree> = TreeMap()
 
     // The set of methods declared on this node.  Will be empty for package
     // nodes and possibly non-empty for class nodes.
-    private val methods_ = HashSet<HasDeclaringClass>()
+    private val methods_ = mutableMapOf<Type, HashSet<HasDeclaringClass>>()
+        .apply { Type.values().forEach { put(it, HashSet<HasDeclaringClass>()) } }
 
     // The set of fields declared on this node.  Will be empty for package
     // nodes and possibly non-empty for class nodes.
-    private val fields_ = HashSet<HasDeclaringClass>()
+    private val fields_ = mutableMapOf<Type, HashSet<HasDeclaringClass>>()
+        .apply { Type.values().forEach { put(it, HashSet<HasDeclaringClass>()) } }
 
-    val classCount: Int
-        get() {
-            if (classTotal_ == null) {
-                if (isClass_) {
-                    classTotal_ = 1
-                } else {
-                    classTotal_ = children_.values.sumBy { it.classCount }
-                }
-            }
-            return classTotal_!!
-        }
+    val classCount: Int get() = classCount(REFERENCED)
+    val methodCount: Int get() = methodCount(REFERENCED)
+    val fieldCount: Int get() = fieldCount(REFERENCED)
 
-    val methodCount: Int
-        get() {
-            if (methodTotal_ == null) {
-                methodTotal_ = children_.values.sumBy(methods_.size) { it.methodCount }
-            }
-            return methodTotal_!!
-        }
-
-    val fieldCount: Int
-        get() {
-            if (fieldTotal_ == null) {
-                fieldTotal_ = children_.values.sumBy(fields_.size) { it.fieldCount }
-            }
-            return fieldTotal_!!
-        }
+    val classCountDeclared: Int get() = classCount(DECLARED)
+    val methodCountDeclared: Int get() = methodCount(DECLARED)
+    val fieldCountDeclared: Int get() = fieldCount(DECLARED)
 
     constructor() : this("", false, null)
 
@@ -98,31 +83,39 @@ class PackageTree(
     constructor(name: String, deobfuscator: Deobfuscator) : this(name, isClassName(name), deobfuscator)
 
     fun addMethodRef(method: MethodRef) {
-        addInternal(descriptorToDot(method), 0, true, method)
+        addInternal(descriptorToDot(method), 0, true, REFERENCED, method)
     }
 
     fun addFieldRef(field: FieldRef) {
-        addInternal(descriptorToDot(field), 0, false, field)
+        addInternal(descriptorToDot(field), 0, false, REFERENCED, field)
     }
 
-    private fun addInternal(name: String, startIndex: Int, isMethod: Boolean, ref: HasDeclaringClass) {
+    fun addDeclaredMethodRef(method: MethodRef) {
+        addInternal(descriptorToDot(method), 0, true, DECLARED, method)
+    }
+
+    fun addDeclaredFieldRef(field: FieldRef) {
+        addInternal(descriptorToDot(field), 0, false, DECLARED, field)
+    }
+
+    private fun addInternal(name: String, startIndex: Int, isMethod: Boolean, type: Type, ref: HasDeclaringClass) {
         val ix = name.indexOf('.', startIndex)
         val segment = if (ix == -1) name.substring(startIndex) else name.substring(startIndex, ix)
         val child = children_.getOrPut(segment) { PackageTree(segment, deobfuscator_) }
 
         if (ix == -1) {
             if (isMethod) {
-                child.methods_.add(ref as MethodRef)
+                child.methods_[type]!!.add(ref as MethodRef)
             } else {
-                child.fields_.add(ref as FieldRef)
+                child.fields_[type]!!.add(ref as FieldRef)
             }
         } else {
             if (isMethod) {
-                methodTotal_ = null
+                methodTotal_.remove(type)
             } else {
-                fieldTotal_ = null
+                fieldTotal_.remove(type)
             }
-            child.addInternal(name, ix + 1, isMethod, ref)
+            child.addInternal(name, ix + 1, isMethod, type, ref)
         }
     }
 
@@ -299,15 +292,15 @@ class PackageTree(
         out.append("---\n")
 
         if (opts.includeClassCount) {
-            out.append("classes: " + classCount + "\n")
+            out.append("classes: $classCount\n")
         }
 
         if (opts.includeMethodCount) {
-            out.append("methods: " + methodCount + "\n")
+            out.append("methods: $methodCount\n")
         }
 
         if (opts.includeFieldCount) {
-            out.append("fields: " + fieldCount + "\n")
+            out.append("fields: $fieldCount\n")
         }
 
         out.append("counts:\n")
@@ -380,9 +373,43 @@ class PackageTree(
             // will not appear in the output in the current PackageTree
             // implementation if classes are not included.  To work around,
             // we make an artificial package named "<unnamed>".
-            "<unnamed>." + deobfuscated
+            "<unnamed>.$deobfuscated"
         } else {
             deobfuscated
         }
+    }
+
+    private fun classCount(type: Type): Int =
+        classTotal_.getOrPut(type) {
+            if (isClass_) {
+                1
+            } else {
+                children_.values.sumBy {
+                    when (type) {
+                        REFERENCED -> it.classCount
+                        DECLARED -> it.classCountDeclared
+                    }
+                }
+            }
+        }
+
+    private fun methodCount(type: Type): Int =
+        methodTotal_.getOrPut(type) { children_.values.sumBy(methods_[type]!!.size) {
+            when (type) {
+                REFERENCED -> it.methodCount
+                DECLARED -> it.methodCountDeclared
+            }
+        } }
+
+    private fun fieldCount(type: Type): Int =
+        fieldTotal_.getOrPut(type) { children_.values.sumBy(fields_[type]!!.size) {
+            when (type) {
+                REFERENCED -> it.fieldCount
+                DECLARED -> it.fieldCountDeclared
+            }
+        } }
+
+    private enum class Type {
+        DECLARED, REFERENCED
     }
 }

--- a/src/main/kotlin/com/getkeepsafe/dexcount/PackageTree.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/PackageTree.kt
@@ -133,6 +133,10 @@ class PackageTree(
 
         if (opts.includeTotalMethodCount) {
             out.appendln("Total methods: $methodCount")
+
+            if (opts.printDeclarations) {
+                out.appendln("Total declared methods: $methodCountDeclared")
+            }
         }
 
         if (opts.printHeader) {
@@ -153,6 +157,11 @@ class PackageTree(
 
         if (opts.includeFieldCount) {
             out.append(String.format("%-8s ", "fields"))
+        }
+
+        if (opts.printDeclarations) {
+            out.append(String.format("%-16s ", "declared methods"))
+            out.append(String.format("%-16s ", "declared fields"))
         }
 
         out.append("package/class name")
@@ -181,6 +190,17 @@ class PackageTree(
 
             if (opts.includeFieldCount) {
                 out.append(String.format("%-8d ", fieldCount))
+            }
+
+            if (opts.printDeclarations) {
+                if (opts.printHeader) {
+                    // The header for the these two columns uses more space.
+                    out.append(String.format("%-16d ", methodCountDeclared))
+                    out.append(String.format("%-16d ", fieldCountDeclared))
+                } else {
+                    out.append(String.format("%-8d ", methodCountDeclared))
+                    out.append(String.format("%-8d ", fieldCountDeclared))
+                }
             }
 
             out.appendln(sb.toString())
@@ -224,7 +244,17 @@ class PackageTree(
                 if (appended) {
                     out.append(", ")
                 }
-                out.append("$fieldCount ${pluralizeFields(fieldCount)}")
+                out.append("$fieldCount ${pluralizedFields(fieldCount)}")
+                appended = true
+            }
+
+            if (opts.printDeclarations) {
+                if (appended) {
+                    out.append(", ")
+                }
+                out.append("$methodCountDeclared declared ${pluralizedMethods(methodCountDeclared)}")
+                    .append(", ")
+                    .append("$fieldCountDeclared declared ${pluralizedFields(fieldCountDeclared)}")
             }
 
             out.append(")")
@@ -278,6 +308,11 @@ class PackageTree(
             json.name("fields").value(fieldCount)
         }
 
+        if (opts.printDeclarations) {
+            json.name("declared_methods").value(methodCountDeclared)
+            json.name("declared_fields").value(fieldCountDeclared)
+        }
+
         json.name("children")
         json.beginArray()
 
@@ -301,6 +336,11 @@ class PackageTree(
 
         if (opts.includeFieldCount) {
             out.append("fields: $fieldCount\n")
+        }
+
+        if (opts.printDeclarations) {
+            out.append("declared_methods: $methodCountDeclared\n")
+            out.append("declared_fields: $fieldCountDeclared\n")
         }
 
         out.append("counts:\n")
@@ -329,6 +369,11 @@ class PackageTree(
 
         if (opts.includeFieldCount) {
             out.appendln("${indentText}fields: $fieldCount")
+        }
+
+        if (opts.printDeclarations) {
+            out.appendln("${indentText}declared_methods: $methodCountDeclared")
+            out.appendln("${indentText}declared_fields: $fieldCountDeclared")
         }
 
         val children = if ((depth + 1) == opts.maxTreeDepth) emptyList() else getChildren(opts)
@@ -362,7 +407,7 @@ class PackageTree(
 
     private fun pluralizedMethods(n: Int) = if (n == 1) "method" else "methods"
 
-    private fun pluralizeFields(n: Int) = if (n == 1) "field" else "fields"
+    private fun pluralizedFields(n: Int) = if (n == 1) "field" else "fields"
 
     private fun descriptorToDot(ref: HasDeclaringClass): String {
         val descriptor = ref.declClassName

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -31,6 +31,9 @@ import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.plugins.JavaLibraryPlugin
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.jvm.tasks.Jar
 import java.io.File
 import java.lang.reflect.Method
 import kotlin.reflect.KClass
@@ -137,6 +140,14 @@ abstract class TaskProvider(
                 ext!!.libraryVariants
             }
 
+            project.plugins.hasPlugin(JavaPlugin::class.java) || project.plugins.hasPlugin(JavaLibraryPlugin::class.java) -> {
+                val jar = project.tasks.findByName("jar") as? Jar
+                    ?: throw IllegalArgumentException("Jar task is null for $project")
+
+                applyToJavaProject(jar)
+                return
+            }
+
             else -> throw IllegalArgumentException("Dexcount plugin requires the Android plugin to be configured")
         }
 
@@ -158,6 +169,14 @@ abstract class TaskProvider(
     abstract fun applyToApplicationVariant(variant: ApplicationVariant)
     abstract fun applyToTestVariant(variant: TestVariant)
     abstract fun applyToLibraryVariant(variant: LibraryVariant)
+
+    private fun applyToJavaProject(jarTask: Jar) {
+        createTaskForJavaProject(ModernMethodCountTask::class, jarTask) { t ->
+            checkPrintDeclarationsIsTrue()
+
+            t.inputFileProvider = { jarTask.archivePath }
+        }
+    }
 
     protected fun addDexcountTaskToGraph(parentTask: Task, dexcountTask: DexMethodCountTaskBase) {
         // Dexcount tasks require that their parent task has been run...
@@ -210,8 +229,42 @@ abstract class TaskProvider(
         }
     }
 
+    protected fun <T : DexMethodCountTaskBase> createTaskForJavaProject(
+            taskClass: KClass<T>,
+            jarTask: Jar,
+            applyInputConfiguration: (T) -> Unit): org.gradle.api.tasks.TaskProvider<T>  {
+
+        return project.tasks.register("countDeclaredMethods", taskClass.java) { task ->
+            val outputDir = "${project.buildDir}/dexcount"
+
+            task.apply {
+                description = "Outputs declared method count."
+                group = "Reporting"
+                variantOutputName = ""
+                mappingFile = null
+                outputFile = File(outputDir, name + (ext.format as OutputFormat).extension)
+                summaryFile = File(outputDir, "$name.csv")
+                chartDir = File(outputDir, name + "Chart")
+                config = ext
+
+                applyInputConfiguration(this)
+            }
+
+            task.dependsOn(jarTask)
+            task.mustRunAfter(jarTask)
+
+            if (ext.runOnEachPackage) {
+                jarTask.finalizedBy(task)
+            }
+        }
+    }
+
     protected fun checkPrintDeclarationsIsFalse() {
         check(!ext.printDeclarations) { "Cannot compute declarations for project $project" }
+    }
+
+    protected fun checkPrintDeclarationsIsTrue() {
+        check(ext.printDeclarations) { "printDeclarations must be true for Java projects: $project" }
     }
 }
 

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -209,6 +209,10 @@ abstract class TaskProvider(
             applyInputConfiguration(this)
         }
     }
+
+    protected fun checkPrintDeclarationsIsFalse() {
+        check(!ext.printDeclarations) { "Cannot compute declarations for project $project" }
+    }
 }
 
 class LegacyProvider(project: Project) : TaskProvider(project) {
@@ -228,6 +232,8 @@ class LegacyProvider(project: Project) : TaskProvider(project) {
     }
 
     private fun applyToApkVariant(variant: ApkVariant) {
+        checkPrintDeclarationsIsFalse()
+
         getOutputsForVariant(variant).forEach { output ->
             val task = createTask(LegacyMethodCountTask::class, variant, output) { t -> t.variantOutput = output }
             addDexcountTaskToGraph(output.assemble, task)
@@ -253,6 +259,8 @@ class ThreeOhProvider(project: Project) : TaskProvider(project) {
     }
 
     private fun applyToApkVariant(variant: ApkVariant) {
+        checkPrintDeclarationsIsFalse()
+
         variant.outputs.all { output ->
             if (output is ApkVariantOutput) {
                 // why wouldn't it be?
@@ -292,6 +300,8 @@ class ThreeThreeProvider(project: Project): TaskProvider(project) {
     }
 
     private fun applyToApkVariant(variant: ApkVariant) {
+        checkPrintDeclarationsIsFalse()
+
         variant.outputs.all { output ->
             if (output !is ApkVariantOutput) {
                 throw IllegalArgumentException("Unexpected output type for variant ${variant.name}: ${output::class.java}")

--- a/src/main/kotlin/com/getkeepsafe/dexcount/PrintOptions.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/PrintOptions.kt
@@ -26,4 +26,5 @@ class PrintOptions {
     var printHeader: Boolean = false
     var orderByMethodCount: Boolean = false
     var maxTreeDepth = Integer.MAX_VALUE
+    var printDeclarations = false
 }

--- a/src/main/kotlin/com/getkeepsafe/dexcount/PrintOptions.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/PrintOptions.kt
@@ -16,15 +16,16 @@
 
 package com.getkeepsafe.dexcount
 
-class PrintOptions {
-    var includeClasses: Boolean = false
-    var includeClassCount: Boolean = false
-    var includeMethodCount: Boolean = true
-    var includeFieldCount: Boolean = false
-    var includeTotalMethodCount: Boolean = false
-    var teamCityIntegration: Boolean = false
-    var printHeader: Boolean = false
-    var orderByMethodCount: Boolean = false
-    var maxTreeDepth = Integer.MAX_VALUE
-    var printDeclarations = false
-}
+data class PrintOptions(
+    var includeClasses: Boolean = false,
+    var includeClassCount: Boolean = false,
+    var includeMethodCount: Boolean = true,
+    var includeFieldCount: Boolean = false,
+    var includeTotalMethodCount: Boolean = false,
+    var teamCityIntegration: Boolean = false,
+    var printHeader: Boolean = false,
+    var orderByMethodCount: Boolean = false,
+    var maxTreeDepth: Int = Integer.MAX_VALUE,
+    var printDeclarations: Boolean = false,
+    var isAndroidProject: Boolean = true
+)

--- a/src/main/kotlin/com/getkeepsafe/dexcount/SourceFile.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/SourceFile.kt
@@ -213,10 +213,17 @@ internal class JarFile(
                 }
             }
 
+            return extractJarFromJar(tempClasses).also {
+                check(tempClasses.deleteRecursively()) { "Couldn't delete $tempClasses" }
+            }
+        }
+
+        @JvmStatic
+        fun extractJarFromJar(jarFile: File): JarFile {
             // Unzip the classes.jar file and store all .class files in this directory.
             val classFilesDir = createTempDir(prefix = "classFilesDir")
 
-            ZipFile(tempClasses).use { zip ->
+            ZipFile(jarFile).use { zip ->
                 zip.entries()
                     .asSequence()
                     .filter { it.name.endsWith(".class") }
@@ -255,7 +262,6 @@ internal class JarFile(
                 .use { it.readLines() }
                 .map { it.trim() }
 
-            check(tempClasses.deleteRecursively()) { "Couldn't delete $tempClasses" }
             check(classFilesDir.deleteRecursively()) { "Couldn't delete $classFilesDir" }
 
             return parseJavapOutput(lines)

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Tasks.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Tasks.kt
@@ -90,18 +90,19 @@ abstract class DexMethodCountTaskBase: DefaultTask() {
     private var outputTime  = 0L
 
     private val printOptions by lazy { // needs to be lazy because config is lateinit
-        PrintOptions().apply {
-            includeClassCount       = config.includeClassCount
-            includeMethodCount      = true
-            includeFieldCount       = config.includeFieldCount
-            includeTotalMethodCount = config.includeTotalMethodCount
-            teamCityIntegration     = config.teamCityIntegration
-            orderByMethodCount      = config.orderByMethodCount
-            includeClasses          = config.includeClasses
-            printHeader             = true
-            maxTreeDepth            = config.maxTreeDepth
-            printDeclarations       = config.printDeclarations
-        }
+        PrintOptions(
+            includeClassCount = config.includeClassCount,
+            includeMethodCount = true,
+            includeFieldCount = config.includeFieldCount,
+            includeTotalMethodCount = config.includeTotalMethodCount,
+            teamCityIntegration = config.teamCityIntegration,
+            orderByMethodCount = config.orderByMethodCount,
+            includeClasses = config.includeClasses,
+            printHeader = true,
+            maxTreeDepth = config.maxTreeDepth,
+            printDeclarations = config.printDeclarations,
+            isAndroidProject = isAndroidProject
+        )
     }
 
     private val deobfuscator by lazy {

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Tasks.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Tasks.kt
@@ -117,6 +117,7 @@ abstract class DexMethodCountTaskBase: DefaultTask() {
     }
 
     private var isInstantRun = false
+    private var isAndroidProject = true
 
     abstract val fileToCount: File?
 
@@ -166,12 +167,23 @@ abstract class DexMethodCountTaskBase: DefaultTask() {
      * counts of the current dex/apk file.
      */
     private fun generatePackageTree() {
-        val file = fileToCount ?: throw AssertionError("file is null: rawInput=${rawInputRepresentation}")
+        val file = fileToCount ?: throw AssertionError("file is null: rawInput=$rawInputRepresentation")
+
+        val isApk = file.extension == "apk"
+        val isAar = file.extension == "aar"
+        val isJar = file.extension == "jar"
+        isAndroidProject = isAar || isApk
+
+        check(isApk || isAar || isJar) { "File extension is unclear: $file" }
 
         startTime = System.currentTimeMillis()
 
-        val dataList = DexFile.extractDexData(file, config.dxTimeoutSec)
-        val jarFile = if (config.printDeclarations) JarFile.extractJarFromAar(file) else null
+        val dataList = if (isAndroidProject) DexFile.extractDexData(file, config.dxTimeoutSec) else emptyList()
+        val jarFile = when {
+            isAar && config.printDeclarations -> JarFile.extractJarFromAar(file)
+            isJar && config.printDeclarations -> JarFile.extractJarFromJar(file)
+            else -> null
+        }
 
         ioTime = System.currentTimeMillis()
         try {
@@ -223,12 +235,18 @@ abstract class DexMethodCountTaskBase: DefaultTask() {
             val fieldsRemaining = Math.max(MAX_DEX_REFS - tree.fieldCount, 0)
             val classesRemaining = Math.max(MAX_DEX_REFS - tree.classCount, 0)
 
-            out.println("Total methods in $filename: ${tree.methodCount} ($percentMethodsUsed% used)")
-            out.println("Total fields in $filename:  ${tree.fieldCount} ($percentFieldsUsed% used)")
-            out.println("Total classes in $filename:  ${tree.classCount} ($percentClassesUsed% used)")
-            out.println("Methods remaining in $filename: $methodsRemaining")
-            out.println("Fields remaining in $filename:  $fieldsRemaining")
-            out.println("Classes remaining in $filename:  $classesRemaining")
+            if (isAndroidProject) {
+                out.println("Total methods in $filename: ${tree.methodCount} ($percentMethodsUsed% used)")
+                out.println("Total fields in $filename:  ${tree.fieldCount} ($percentFieldsUsed% used)")
+                out.println("Total classes in $filename:  ${tree.classCount} ($percentClassesUsed% used)")
+                out.println("Methods remaining in $filename: $methodsRemaining")
+                out.println("Fields remaining in $filename:  $fieldsRemaining")
+                out.println("Classes remaining in $filename:  $classesRemaining")
+            } else {
+                out.println("Total methods in $filename: ${tree.methodCountDeclared} ($percentMethodsUsed% used)")
+                out.println("Total fields in $filename:  ${tree.fieldCountDeclared} ($percentFieldsUsed% used)")
+                out.println("Total classes in $filename:  ${tree.classCountDeclared} ($percentClassesUsed% used)")
+            }
         }
 
         summaryFile.parentFile.mkdirs()

--- a/src/test/groovy/com/getkeepsafe/dexcount/JarFileSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/JarFileSpec.groovy
@@ -36,7 +36,7 @@ final class JarFileSpec extends Specification {
 
         then:
         jarFile != null
-        jarFile.methodRefs.size() == 588
-        jarFile.fieldRefs.size() == 372
+        jarFile.methodRefs.size() == 659
+        jarFile.fieldRefs.size() == 405
     }
 }

--- a/src/test/groovy/com/getkeepsafe/dexcount/JarFileSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/JarFileSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 KeepSafe Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.getkeepsafe.dexcount
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+final class JarFileSpec extends Specification {
+    @Rule TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    def "test AAR method count"() {
+        given:
+        def aarFile = temporaryFolder.newFile("test.aar")
+
+        getClass().getResourceAsStream('/android-beacon-library-2.7.aar').withStream { input ->
+            aarFile.append(input)
+        }
+
+        when:
+        def jarFile = JarFile.extractJarFromAar(aarFile)
+
+        then:
+        jarFile != null
+        jarFile.methodRefs.size() == 588
+        jarFile.fieldRefs.size() == 372
+    }
+}

--- a/src/test/groovy/com/getkeepsafe/dexcount/PackageTreeSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/PackageTreeSpec.groovy
@@ -638,6 +638,48 @@ final class PackageTreeSpec extends Specification {
         trimmed == expected
     }
 
+    def "package list can include class count in java project"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.isAndroidProject = false
+        opts.printHeader = true
+        opts.includeClassCount = true
+        opts.includeMethodCount = true
+        opts.includeFieldCount = true
+        opts.printDeclarations = true
+
+        when:
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Class1;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Class1;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Class2;"))
+        tree.addDeclaredMethodRef(methodRef("Lorg/whatever/Foo;"))
+        tree.addDeclaredMethodRef(methodRef("Lorg/foo/Whatever;"))
+        tree.addDeclaredFieldRef(fieldRef("Lcom/foo/Class1;"))
+        tree.addDeclaredFieldRef(fieldRef("Lcom/foo/Class2;"))
+        tree.addDeclaredFieldRef(fieldRef("Lcom/foo/Class2;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/Z;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/W;"))
+
+        tree.printPackageList(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+            classes  declared methods declared fields  package/class name
+            2        3                3                com
+            2        3                3                com.foo
+            2        2                0                org
+            1        1                0                org.foo
+            1        1                0                org.whatever
+            2        0                2                x
+            2        0                2                x.y
+            """.stripIndent().trim()
+
+        trimmed == expected
+    }
+
     def "package list can be depth-limited"() {
         given:
         def tree = new PackageTree()

--- a/src/test/groovy/com/getkeepsafe/dexcount/PackageTreeSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/PackageTreeSpec.groovy
@@ -78,6 +78,32 @@ final class PackageTreeSpec extends Specification {
         trimmed == expected
     }
 
+    def "can print a package list with classes and declarations included"() {
+        given:
+        def writer = new StringBuilder()
+        def tree = new PackageTree()
+
+        when:
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Qux;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/alpha/Beta;"))
+
+        tree.printPackageList(writer, new PrintOptions(includeClasses: true, printDeclarations: true))
+
+        then:
+        def trimmed = writer.toString().stripIndent().trim()
+        def expected = """
+            0        4        0        com
+            0        1        0        com.alpha
+            0        1        0        com.alpha.Beta
+            0        3        0        com.foo
+            0        2        0        com.foo.Bar
+            0        1        0        com.foo.Qux""".stripIndent().trim()
+
+        trimmed == expected
+    }
+
     def "can print a package list without classes"() {
         given:
         def writer = new StringBuilder()
@@ -97,6 +123,30 @@ final class PackageTreeSpec extends Specification {
             4        com
             1        com.alpha
             3        com.foo
+            """.stripIndent().trim()
+
+        trimmed == expected
+    }
+
+    def "can print a package list without classes but with declarations"() {
+        given:
+        def writer = new StringBuilder()
+        def tree = new PackageTree()
+
+        when:
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Qux;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/alpha/Beta;"))
+
+        tree.printPackageList(writer, new PrintOptions(includeClasses: false, printDeclarations: true))
+
+        then:
+        def trimmed = writer.toString().stripIndent().trim()
+        def expected = """
+            0        4        0        com
+            0        1        0        com.alpha
+            0        3        0        com.foo
             """.stripIndent().trim()
 
         trimmed == expected
@@ -128,6 +178,32 @@ final class PackageTreeSpec extends Specification {
         trimmed == expected
     }
 
+    def "can print a tree with declarations"() {
+        given:
+        def sb = new StringBuilder()
+        def tree = new PackageTree()
+
+        when:
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Qux;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/alpha/Beta;"))
+
+        tree.printTree(sb, new PrintOptions(includeClasses: true, printDeclarations: true))
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+            com (0 methods, 4 declared methods, 0 declared fields)
+              alpha (0 methods, 1 declared method, 0 declared fields)
+                Beta (0 methods, 1 declared method, 0 declared fields)
+              foo (0 methods, 3 declared methods, 0 declared fields)
+                Bar (0 methods, 2 declared methods, 0 declared fields)
+                Qux (0 methods, 1 declared method, 0 declared fields)""".stripIndent().trim()
+
+        trimmed == expected
+    }
+
     def "tree can be depth-limited"() {
         given:
         def sb = new StringBuilder()
@@ -149,6 +225,32 @@ final class PackageTreeSpec extends Specification {
             com (4 methods)
               alpha (1 method)
               foo (3 methods)""".stripIndent().trim()
+
+        trimmed == expected
+    }
+
+    def "tree can be depth-limited with declarations"() {
+        given:
+        def sb = new StringBuilder()
+        def tree = new PackageTree()
+
+        when:
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Qux;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/alpha/Beta;"))
+
+        tree.printTree(sb, new PrintOptions(
+            includeClasses: true,
+            maxTreeDepth: 2,
+            printDeclarations: true))
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+            com (0 methods, 4 declared methods, 0 declared fields)
+              alpha (0 methods, 1 declared method, 0 declared fields)
+              foo (0 methods, 3 declared methods, 0 declared fields)""".stripIndent().trim()
 
         trimmed == expected
     }
@@ -186,6 +288,24 @@ final class PackageTreeSpec extends Specification {
         trimmed == expected
     }
 
+    def "prints a header when options say to with declarations"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.printHeader = true
+        opts.printDeclarations = true
+
+        when:
+        tree.printPackageList(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = "methods  declared methods declared fields  package/class name".stripIndent().trim()
+
+        trimmed == expected
+    }
+
     def "header includes column for fields when field count is specified"() {
         given:
         def tree = new PackageTree()
@@ -200,6 +320,25 @@ final class PackageTreeSpec extends Specification {
         then:
         def trimmed = sb.toString().stripIndent().trim()
         def expected = "methods  fields   package/class name".stripIndent().trim()
+
+        trimmed == expected
+    }
+
+    def "header includes column for fields when field count is specified with declarations"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.printHeader = true
+        opts.includeFieldCount = true
+        opts.printDeclarations = true
+
+        when:
+        tree.printPackageList(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = "methods  fields   declared methods declared fields  package/class name".stripIndent().trim()
 
         trimmed == expected
     }
@@ -230,6 +369,37 @@ final class PackageTreeSpec extends Specification {
             3        3        x.y
             0        1        x.y.W
             3        2        x.y.Z""".stripIndent().trim()
+
+        trimmed == expected
+    }
+
+    def "package list can include field counts with declarations"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.printHeader = true
+        opts.includeFieldCount = true
+        opts.includeClasses = true
+        opts.printDeclarations = true
+
+        when:
+        tree.addDeclaredMethodRef(methodRef("Lx/y/Z;"))
+        tree.addDeclaredMethodRef(methodRef("Lx/y/Z;"))
+        tree.addDeclaredMethodRef(methodRef("Lx/y/Z;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/Z;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/Z;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/W;"))
+        tree.printPackageList(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+            methods  fields   declared methods declared fields  package/class name
+            0        0        3                3                x
+            0        0        3                3                x.y
+            0        0        0                1                x.y.W
+            0        0        3                2                x.y.Z""".stripIndent().trim()
 
         trimmed == expected
     }
@@ -265,6 +435,45 @@ final class PackageTreeSpec extends Specification {
         trimmed == expected
     }
 
+    def "package list can be sorted by method count with declarations"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.printHeader = true
+        opts.includeFieldCount = true
+        opts.includeClasses = true
+        opts.orderByMethodCount = true
+        opts.printDeclarations = true
+
+        when:
+        tree.addMethodRef(methodRef("Lx/y/Z;"))
+        tree.addMethodRef(methodRef("Lx/y/Z;"))
+        tree.addMethodRef(methodRef("Lx/y/Z;"))
+        tree.addFieldRef(fieldRef("Lx/y/Z;"))
+        tree.addFieldRef(fieldRef("Lx/y/Z;"))
+        tree.addFieldRef(fieldRef("Lx/y/W;"))
+
+        tree.addDeclaredMethodRef(methodRef("Lx/y/Z;"))
+        tree.addDeclaredMethodRef(methodRef("Lx/y/Z;"))
+        tree.addDeclaredMethodRef(methodRef("Lx/y/Z;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/Z;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/Z;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/W;"))
+        tree.printPackageList(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+            methods  fields   declared methods declared fields  package/class name
+            3        3        3                3                x
+            3        3        3                3                x.y
+            3        2        3                2                x.y.Z
+            0        1        0                1                x.y.W""".stripIndent().trim()
+
+        trimmed == expected
+    }
+
     def "package list can include total method count"() {
         given:
         def tree = new PackageTree()
@@ -293,6 +502,47 @@ final class PackageTreeSpec extends Specification {
             2        org
             1        org.foo
             1        org.whatever
+            """.stripIndent().trim()
+
+        trimmed == expected
+    }
+
+    def "package list can include total method count with declarations"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.includeTotalMethodCount = true
+        opts.includeClasses = false
+        opts.printHeader = false
+        opts.printDeclarations = true
+
+        when:
+        tree.addMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addMethodRef(methodRef("Lcom/foo/Qux;"))
+        tree.addMethodRef(methodRef("Lcom/alpha/Beta;"))
+        tree.addMethodRef(methodRef("Lorg/whatever/Foo;"))
+        tree.addMethodRef(methodRef("Lorg/foo/Whatever;"))
+
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Qux;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/alpha/Beta;"))
+        tree.addDeclaredMethodRef(methodRef("Lorg/whatever/Foo;"))
+        tree.addDeclaredMethodRef(methodRef("Lorg/foo/Whatever;"))
+
+        tree.printPackageList(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+            Total methods: 5
+            Total declared methods: 5
+            3        3        0        com
+            1        1        0        com.alpha
+            2        2        0        com.foo
+            2        2        0        org
+            1        1        0        org.foo
+            1        1        0        org.whatever
             """.stripIndent().trim()
 
         trimmed == expected
@@ -338,6 +588,56 @@ final class PackageTreeSpec extends Specification {
         trimmed == expected
     }
 
+    def "package list can include class count with declarations"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.printHeader = true
+        opts.includeClassCount = true
+        opts.includeMethodCount = true
+        opts.includeFieldCount = true
+        opts.printDeclarations = true
+
+        when:
+        tree.addMethodRef(methodRef("Lcom/foo/Class1;"))
+        tree.addMethodRef(methodRef("Lcom/foo/Class2;"))
+        tree.addMethodRef(methodRef("Lorg/whatever/Foo;"))
+        tree.addMethodRef(methodRef("Lorg/foo/Whatever;"))
+        tree.addFieldRef(fieldRef("Lcom/foo/Class1;"))
+        tree.addFieldRef(fieldRef("Lcom/foo/Class2;"))
+        tree.addFieldRef(fieldRef("Lx/y/Z;"))
+        tree.addFieldRef(fieldRef("Lx/y/W;"))
+
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Class1;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Class1;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Class2;"))
+        tree.addDeclaredMethodRef(methodRef("Lorg/whatever/Foo;"))
+        tree.addDeclaredMethodRef(methodRef("Lorg/foo/Whatever;"))
+        tree.addDeclaredFieldRef(fieldRef("Lcom/foo/Class1;"))
+        tree.addDeclaredFieldRef(fieldRef("Lcom/foo/Class2;"))
+        tree.addDeclaredFieldRef(fieldRef("Lcom/foo/Class2;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/Z;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/W;"))
+
+        tree.printPackageList(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+            classes  methods  fields   declared methods declared fields  package/class name
+            2        2        2        3                3                com
+            2        2        2        3                3                com.foo
+            2        2        0        2                0                org
+            1        1        0        1                0                org.foo
+            1        1        0        1                0                org.whatever
+            2        0        2        0                2                x
+            2        0        2        0                2                x.y
+            """.stripIndent().trim()
+
+        trimmed == expected
+    }
+
     def "package list can be depth-limited"() {
         given:
         def tree = new PackageTree()
@@ -363,6 +663,38 @@ final class PackageTreeSpec extends Specification {
             Total methods: 5
             3        com
             2        org
+            """.stripIndent().trim()
+
+        trimmed == expected
+    }
+
+    def "package list can be depth-limited with declarations"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.includeTotalMethodCount = true
+        opts.includeClasses = false
+        opts.printHeader = false
+        opts.maxTreeDepth = 1
+        opts.printDeclarations = true
+
+        when:
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Qux;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/alpha/Beta;"))
+        tree.addDeclaredMethodRef(methodRef("Lorg/whatever/Foo;"))
+        tree.addDeclaredMethodRef(methodRef("Lorg/foo/Whatever;"))
+
+        tree.printPackageList(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+            Total methods: 0
+            Total declared methods: 5
+            0        3        0        com
+            0        2        0        org
             """.stripIndent().trim()
 
         trimmed == expected
@@ -407,6 +739,65 @@ final class PackageTreeSpec extends Specification {
                     children: []
                   - name: whatever
                     methods: 1
+                    children: []""".stripIndent().trim()
+
+        trimmed == expected
+    }
+
+    def "packages can be YAML-formatted with declarations"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.includeTotalMethodCount = true
+        opts.printDeclarations = true
+
+        when:
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Qux;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/alpha/Beta;"))
+        tree.addDeclaredMethodRef(methodRef("Lorg/whatever/Foo;"))
+        tree.addDeclaredMethodRef(methodRef("Lorg/foo/Whatever;"))
+
+        tree.printYaml(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+            ---
+            methods: 0
+            declared_methods: 5
+            declared_fields: 0
+            counts:
+              - name: com
+                methods: 0
+                declared_methods: 3
+                declared_fields: 0
+                children:
+                  - name: alpha
+                    methods: 0
+                    declared_methods: 1
+                    declared_fields: 0
+                    children: []
+                  - name: foo
+                    methods: 0
+                    declared_methods: 2
+                    declared_fields: 0
+                    children: []
+              - name: org
+                methods: 0
+                declared_methods: 2
+                declared_fields: 0
+                children:
+                  - name: foo
+                    methods: 0
+                    declared_methods: 1
+                    declared_fields: 0
+                    children: []
+                  - name: whatever
+                    methods: 0
+                    declared_methods: 1
+                    declared_fields: 0
                     children: []""".stripIndent().trim()
 
         trimmed == expected
@@ -459,6 +850,68 @@ final class PackageTreeSpec extends Specification {
         trimmed == expected
     }
 
+    def "can format YAML with only class counts with declarations"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.includeTotalMethodCount = true
+        opts.includeClassCount = true
+        opts.includeMethodCount = false
+        opts.printDeclarations = true
+
+        tree.addDeclaredFieldRef(fieldRef("Lorg/whatever/Foo;"))
+        tree.addDeclaredMethodRef(methodRef("Lorg/whatever/Foo;"))
+        tree.addDeclaredMethodRef(methodRef("Lorg/foo/Whatever;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/z/XYZ;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/z/XYZ;"))
+        tree.addDeclaredMethodRef(methodRef("Lx/y/z/XYZ;"))
+
+        when:
+        tree.printYaml(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+            ---
+            classes: 3
+            declared_methods: 3
+            declared_fields: 3
+            counts:
+              - name: org
+                classes: 2
+                declared_methods: 2
+                declared_fields: 1
+                children:
+                  - name: foo
+                    classes: 1
+                    declared_methods: 1
+                    declared_fields: 0
+                    children: []
+                  - name: whatever
+                    classes: 1
+                    declared_methods: 1
+                    declared_fields: 1
+                    children: []
+              - name: x
+                classes: 1
+                declared_methods: 1
+                declared_fields: 2
+                children:
+                  - name: y
+                    classes: 1
+                    declared_methods: 1
+                    declared_fields: 2
+                    children:
+                      - name: z
+                        classes: 1
+                        declared_methods: 1
+                        declared_fields: 2
+                        children: []""".stripIndent().trim()
+
+        trimmed == expected
+    }
+
     def "can format YAML with only field counts"() {
         given:
         def tree = new PackageTree()
@@ -505,6 +958,67 @@ final class PackageTreeSpec extends Specification {
         trimmed == expected
     }
 
+    def "can format YAML with only field counts with declarations"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.includeTotalMethodCount = true
+        opts.includeFieldCount = true
+        opts.includeMethodCount = false
+        opts.printDeclarations = true
+
+        tree.addDeclaredFieldRef(fieldRef("Lcom/foo/Bar;"))
+        tree.addDeclaredFieldRef(fieldRef("Lcom/foo/Qux;"))
+        tree.addDeclaredFieldRef(fieldRef("Lcom/alpha/Beta;"))
+        tree.addDeclaredFieldRef(fieldRef("Lorg/whatever/Foo;"))
+        tree.addDeclaredFieldRef(fieldRef("Lorg/foo/Whatever;"))
+
+        when:
+        tree.printYaml(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+            ---
+            fields: 0
+            declared_methods: 0
+            declared_fields: 5
+            counts:
+              - name: com
+                fields: 0
+                declared_methods: 0
+                declared_fields: 3
+                children:
+                  - name: alpha
+                    fields: 0
+                    declared_methods: 0
+                    declared_fields: 1
+                    children: []
+                  - name: foo
+                    fields: 0
+                    declared_methods: 0
+                    declared_fields: 2
+                    children: []
+              - name: org
+                fields: 0
+                declared_methods: 0
+                declared_fields: 2
+                children:
+                  - name: foo
+                    fields: 0
+                    declared_methods: 0
+                    declared_fields: 1
+                    children: []
+                  - name: whatever
+                    fields: 0
+                    declared_methods: 0
+                    declared_fields: 1
+                    children: []""".stripIndent().trim()
+
+        trimmed == expected
+    }
+
     def "can format depth-limited YAML"() {
         given:
         def tree = new PackageTree()
@@ -535,6 +1049,48 @@ final class PackageTreeSpec extends Specification {
                 children: []
               - name: org
                 fields: 2
+                children: []""".stripIndent().trim()
+
+        trimmed == expected
+    }
+
+    def "can format depth-limited YAML with declarations"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.includeTotalMethodCount = true
+        opts.includeFieldCount = true
+        opts.includeMethodCount = false
+        opts.maxTreeDepth = 1
+        opts.printDeclarations = true
+
+        tree.addDeclaredFieldRef(fieldRef("Lcom/foo/Bar;"))
+        tree.addDeclaredFieldRef(fieldRef("Lcom/foo/Qux;"))
+        tree.addDeclaredFieldRef(fieldRef("Lcom/alpha/Beta;"))
+        tree.addDeclaredFieldRef(fieldRef("Lorg/whatever/Foo;"))
+        tree.addDeclaredFieldRef(fieldRef("Lorg/foo/Whatever;"))
+
+        when:
+        tree.printYaml(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+            ---
+            fields: 0
+            declared_methods: 0
+            declared_fields: 5
+            counts:
+              - name: com
+                fields: 0
+                declared_methods: 0
+                declared_fields: 3
+                children: []
+              - name: org
+                fields: 0
+                declared_methods: 0
+                declared_fields: 2
                 children: []""".stripIndent().trim()
 
         trimmed == expected
@@ -585,6 +1141,76 @@ final class PackageTreeSpec extends Specification {
                             {
                               "name": "z",
                               "classes": 1,
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }""".stripIndent().trim()
+
+        trimmed == expected
+    }
+
+    def "can format JSON with only class counts with declarations"() {
+        given:
+        def tree = new PackageTree()
+        def sb = new StringBuilder()
+        def opts = new PrintOptions()
+        opts.includeTotalMethodCount = true
+        opts.includeClassCount = true
+        opts.includeMethodCount = false
+        opts.printDeclarations = true
+
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Qux;"))
+        tree.addDeclaredFieldRef(fieldRef("Lx/y/z/XYZ;"))
+
+        when:
+        tree.printJson(sb, opts)
+
+        then:
+        def trimmed = sb.toString().stripIndent().trim()
+        def expected = """
+                {
+                  "name": "",
+                  "classes": 3,
+                  "declared_methods": 2,
+                  "declared_fields": 1,
+                  "children": [
+                    {
+                      "name": "com",
+                      "classes": 2,
+                      "declared_methods": 2,
+                      "declared_fields": 0,
+                      "children": [
+                        {
+                          "name": "foo",
+                          "classes": 2,
+                          "declared_methods": 2,
+                          "declared_fields": 0,
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "x",
+                      "classes": 1,
+                      "declared_methods": 0,
+                      "declared_fields": 1,
+                      "children": [
+                        {
+                          "name": "y",
+                          "classes": 1,
+                          "declared_methods": 0,
+                          "declared_fields": 1,
+                          "children": [
+                            {
+                              "name": "z",
+                              "classes": 1,
+                              "declared_methods": 0,
+                              "declared_fields": 1,
                               "children": []
                             }
                           ]

--- a/src/test/groovy/com/getkeepsafe/dexcount/PackageTreeSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/PackageTreeSpec.groovy
@@ -29,9 +29,12 @@ final class PackageTreeSpec extends Specification {
         when:
         tree.addMethodRef(methodRef("Lcom/foo/Bar;", "foo"))
         tree.addMethodRef(methodRef("Lcom/foo/Bar;", "bar"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;", "foo"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;", "bar"))
 
         then:
         tree.methodCount == 2
+        tree.methodCountDeclared == 2
     }
 
     def "adding duplicate methods does not increment count"() {
@@ -41,9 +44,12 @@ final class PackageTreeSpec extends Specification {
         when:
         tree.addMethodRef(methodRef("Lcom/foo/Bar;", "foo"))
         tree.addMethodRef(methodRef("Lcom/foo/Bar;", "foo"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;", "foo"))
+        tree.addDeclaredMethodRef(methodRef("Lcom/foo/Bar;", "foo"))
 
         then:
         tree.methodCount == 1
+        tree.methodCountDeclared == 1
     }
 
     def "can print a package list with classes included"() {


### PR DESCRIPTION
I broke down the PR into smaller commits. It might be easier to review them individually. This PR resolves #270. 

Overall this PR adds one new parameter `printDeclarations` to the extension. When turned on the report prints also declared methods in separate columns. This only works for AARs, because I couldn't find a good way to find the `.jar` file for APKs. 

Additionally, I've added support for the `java` and `java-library` plugin. There `printDeclarations` must be turned on and the report only contains the declarations and not references. 