### PR TITLE
Better property API usage, also minify in integration tests

### DIFF
--- a/.buildscript/test.sh
+++ b/.buildscript/test.sh
@@ -23,22 +23,22 @@ function die() {
   exit 1
 }
 
-grep -F 'Total methods in app-debug.apk: 15116 (23.07% used)' app.log || die "Incorrect method count in app-debug.apk"
-grep -F 'Total fields in app-debug.apk:  10120 (15.44% used)' app.log || die "Incorrect field count in app-debug.apk"
-grep -F 'Total classes in app-debug.apk:  1761 (2.69% used)' app.log || die "Incorrect field count in app-debug.apk"
-grep -F 'Methods remaining in app-debug.apk: 50419' app.log || die "Incorrect remaining-method value in app-debug.apk"
-grep -F 'Fields remaining in app-debug.apk:  55415' app.log || die "Incorrect remaining-field value in app-debug.apk"
-grep -F 'Classes remaining in app-debug.apk:  63774' app.log || die "Incorrect remaining-field value in app-debug.apk"
+grep -F 'Total methods in app-debug.apk: 7369 (11.24% used)' app.log || die "Incorrect method count in app-debug.apk"
+grep -F 'Total fields in app-debug.apk:  3780 (5.77% used)' app.log || die "Incorrect field count in app-debug.apk"
+grep -F 'Total classes in app-debug.apk:  926 (1.41% used)' app.log || die "Incorrect field count in app-debug.apk"
+grep -F 'Methods remaining in app-debug.apk: 58166' app.log || die "Incorrect remaining-method value in app-debug.apk"
+grep -F 'Fields remaining in app-debug.apk:  61755' app.log || die "Incorrect remaining-field value in app-debug.apk"
+grep -F 'Classes remaining in app-debug.apk:  64609' app.log || die "Incorrect remaining-field value in app-debug.apk"
 
-grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_ClassCount' value='1761']" app.log || die "Missing or incorrect Teamcity method count value"
-grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_MethodCount' value='15116']" app.log || die "Missing or incorrect Teamcity method count value"
-grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_FieldCount' value='10120']" app.log || die "Missing or incorrect Teamcity field count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_ClassCount' value='926']" app.log || die "Missing or incorrect Teamcity method count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_MethodCount' value='7369']" app.log || die "Missing or incorrect Teamcity method count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_FieldCount' value='3780']" app.log || die "Missing or incorrect Teamcity field count value"
 
-grep -F 'Total methods in tests-debug.apk: 4364 (6.66% used)' tests.log || die "Incorrect method count in tests-debug.apk"
-grep -F 'Total fields in tests-debug.apk:  1275 (1.95% used)' tests.log || die "Incorrect field count in tests-debug.apk"
+grep -F 'Total methods in tests-debug.apk: 4265 (6.51% used)' tests.log || die "Incorrect method count in tests-debug.apk"
+grep -F 'Total fields in tests-debug.apk:  1271 (1.94% used)' tests.log || die "Incorrect field count in tests-debug.apk"
 grep -F 'Total classes in tests-debug.apk:  723 (1.10% used)' tests.log || die "Incorrect field count in tests-debug.apk"
-grep -F 'Methods remaining in tests-debug.apk: 61171' tests.log || die "Incorrect remaining-method value in tests-debug.apk"
-grep -F 'Fields remaining in tests-debug.apk:  64260' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
+grep -F 'Methods remaining in tests-debug.apk: 61270' tests.log || die "Incorrect remaining-method value in tests-debug.apk"
+grep -F 'Fields remaining in tests-debug.apk:  64264' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
 grep -F 'Classes remaining in tests-debug.apk:  64812' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
 
 grep -F 'Total methods in lib-debug.aar: 7 (0.01% used)' lib.log || die "Incorrect method count in lib-debug.aar"

--- a/integration/app/build.gradle
+++ b/integration/app/build.gradle
@@ -14,11 +14,11 @@ android {
 
     buildTypes {
         debug {
-            minifyEnabled false
+            minifyEnabled true
         }
 
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }

--- a/integration/tests/build.gradle
+++ b/integration/tests/build.gradle
@@ -20,6 +20,12 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    buildTypes {
+        debug {
+            minifyEnabled true
+        }
+    }
 }
 
 dependencies {

--- a/src/main/kotlin/com/getkeepsafe/dexcount/DexCountTask.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/DexCountTask.kt
@@ -252,7 +252,7 @@ open class DexCountTask: DefaultTask() {
         if (printOptions.teamCityIntegration || config.teamCitySlug != null) {
             withStyledOutput { out ->
                 val slug = "Dexcount" + (config.teamCitySlug?.let { "_" + it.replace(' ', '_') } ?: "")
-                val prefix = "${slug}_$variantOutputName"
+                val prefix = "${slug}_${variantOutputName.get()}"
 
                 /**
                  * Reports to Team City statistic value

--- a/src/main/kotlin/com/getkeepsafe/dexcount/DexCountTask.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/DexCountTask.kt
@@ -18,11 +18,10 @@ package com.getkeepsafe.dexcount
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
@@ -33,7 +32,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import javax.annotation.Nullable
-import javax.inject.Inject
 
 /**
  * The maximum number of method refs and field refs allowed in a single Dex
@@ -42,9 +40,7 @@ import javax.inject.Inject
 const val MAX_DEX_REFS: Int = 0xFFFF // 65535
 
 @Suppress("UnstableApiUsage")
-open class DexCountTask @Inject constructor(
-    objectFactory: ObjectFactory
-): DefaultTask() {
+open class DexCountTask: DefaultTask() {
     private lateinit var tree: PackageTree
 
     /**
@@ -55,26 +51,26 @@ open class DexCountTask @Inject constructor(
     }
 
     @InputFile
-    val inputFileProperty: RegularFileProperty = objectFactory.fileProperty()
+    val inputFileProperty: RegularFileProperty = project.objects.fileProperty()
 
     private val rawInputRepresentation: String
         get() = "${getInputFile()}"
 
     @Input
-    lateinit var variantOutputName: String
+    val variantOutputName: Property<String> = project.objects.property(String::class.java)
 
     @Nullable
     @InputFiles
-    val mappingFileProvider: Property<FileCollection> = objectFactory.property(FileCollection::class.java)
+    val mappingFileProvider: ConfigurableFileCollection = project.objects.fileCollection()
 
     @OutputFile
-    val outputFile: RegularFileProperty = objectFactory.fileProperty()
+    val outputFile: RegularFileProperty = project.objects.fileProperty()
 
     @OutputFile
-    val summaryFile: RegularFileProperty = objectFactory.fileProperty()
+    val summaryFile: RegularFileProperty = project.objects.fileProperty()
 
     @OutputDirectory
-    val chartDir: DirectoryProperty = objectFactory.directoryProperty()
+    val chartDir: DirectoryProperty = project.objects.directoryProperty()
 
     @Nested
     lateinit var config: DexCountExtension
@@ -101,7 +97,7 @@ open class DexCountTask @Inject constructor(
     }
 
     private val deobfuscator by lazy {
-        val fileCollection = mappingFileProvider.get()
+        val fileCollection = mappingFileProvider
         val file = if (fileCollection.isEmpty) null else fileCollection.singleFile
         when {
             file == null -> Deobfuscator.empty

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -221,10 +221,10 @@ abstract class TaskApplicator(
         return project.tasks.create("count${slug}DexMethods", DexCountTask::class.java) { t ->
             t.description         = "Outputs dex method count for ${variant.name}."
             t.group               = "Reporting"
-            t.variantOutputName   = outputName
             t.config              = ext
 
-            t.mappingFileProvider.set(getMappingFile(variant))
+            t.variantOutputName.set(outputName)
+            t.mappingFileProvider.from(getMappingFile(variant))
             t.outputFile.set(project.file(path + (ext.format as OutputFormat).extension))
             t.summaryFile.set(project.file(path + ".csv"))
             t.chartDir.set(project.file(path + "Chart"))
@@ -246,8 +246,8 @@ abstract class TaskApplicator(
             task.apply {
                 description = "Outputs declared method count."
                 group = "Reporting"
-                variantOutputName = ""
-                mappingFileProvider.set(project.files())
+                variantOutputName.set("")
+                mappingFileProvider.from(project.files())
                 outputFile.set(File(outputDir, name + (ext.format as OutputFormat).extension))
                 summaryFile.set(File(outputDir, "$name.csv"))
                 chartDir.set(File(outputDir, name + "Chart"))

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexCountExtensionSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexCountExtensionSpec.groovy
@@ -68,7 +68,7 @@ final class DexCountExtensionSpec extends Specification {
 
         // Override APK file
         DexCountTask task = project.tasks.getByName("countDebugDexMethods") as DexCountTask
-        task.variantOutputName = "extensionSpec"
+        task.variantOutputName.set("extensionSpec")
         task.inputFileProperty.set(apkFile)
         task.execute()
 
@@ -96,7 +96,7 @@ final class DexCountExtensionSpec extends Specification {
 
         // Override APK file
         DexCountTask task = project.tasks.getByName("countDebugDexMethods") as DexCountTask
-        task.variantOutputName = "extensionSpec"
+        task.variantOutputName.set("extensionSpec")
         task.inputFileProperty.set(apkFile)
         task.execute()
 
@@ -125,7 +125,7 @@ final class DexCountExtensionSpec extends Specification {
 
         // Override APK file
         DexCountTask task = project.tasks.getByName("countDebugDexMethods") as DexCountTask
-        task.variantOutputName = "extensionSpec"
+        task.variantOutputName.set("extensionSpec")
         task.inputFileProperty.set(apkFile)
         task.execute()
 

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
@@ -465,7 +465,7 @@ final class DexMethodCountPluginSpec extends Specification {
 
         // Override APK file
         DexCountTask task = project.tasks.getByName('countDebugDexMethods') as DexCountTask
-        task.variantOutputName = 'pluginSpec'
+        task.variantOutputName.set('pluginSpec')
         task.inputFileProperty.set(apkFile)
         task.execute()
 


### PR DESCRIPTION
I forgot one input that should be a property.
Realized that I don't need to inject `ObjectFactory` because tasks have a property reference.
Realized that I could use `ConfigurableFileColllection` instead of `Provider<FileCollection>`.
Realized that we weren't minifying in integration tests, and we should.