### PR TITLE
Allow counting of renamed output files

### DIFF
--- a/.buildscript/test.sh
+++ b/.buildscript/test.sh
@@ -23,12 +23,12 @@ function die() {
   exit 1
 }
 
-grep -F 'Total methods in app-debug.apk: 7369 (11.24% used)' app.log || die "Incorrect method count in app-debug.apk"
-grep -F 'Total fields in app-debug.apk:  3780 (5.77% used)' app.log || die "Incorrect field count in app-debug.apk"
-grep -F 'Total classes in app-debug.apk:  926 (1.41% used)' app.log || die "Incorrect field count in app-debug.apk"
-grep -F 'Methods remaining in app-debug.apk: 58166' app.log || die "Incorrect remaining-method value in app-debug.apk"
-grep -F 'Fields remaining in app-debug.apk:  61755' app.log || die "Incorrect remaining-field value in app-debug.apk"
-grep -F 'Classes remaining in app-debug.apk:  64609' app.log || die "Incorrect remaining-field value in app-debug.apk"
+grep -F 'Total methods in app-debug-it.apk: 7369 (11.24% used)' app.log || die "Incorrect method count in app-debug-it.apk"
+grep -F 'Total fields in app-debug-it.apk:  3780 (5.77% used)' app.log || die "Incorrect field count in app-debug-it.apk"
+grep -F 'Total classes in app-debug-it.apk:  926 (1.41% used)' app.log || die "Incorrect field count in app-debug-it.apk"
+grep -F 'Methods remaining in app-debug-it.apk: 58166' app.log || die "Incorrect remaining-method value in app-debug-it.apk"
+grep -F 'Fields remaining in app-debug-it.apk:  61755' app.log || die "Incorrect remaining-field value in app-debug-it.apk"
+grep -F 'Classes remaining in app-debug-it.apk:  64609' app.log || die "Incorrect remaining-field value in app-debug-it.apk"
 
 grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_ClassCount' value='926']" app.log || die "Missing or incorrect Teamcity method count value"
 grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_MethodCount' value='7369']" app.log || die "Missing or incorrect Teamcity method count value"

--- a/integration/app/build.gradle
+++ b/integration/app/build.gradle
@@ -22,6 +22,12 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+
+    applicationVariants.all { variant ->
+        variant.outputs.all { output ->
+            output.outputFileName = output.outputFileName.replace(".apk", "-it.apk")
+        }
+    }
 }
 
 dexcount {

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -315,7 +315,7 @@ class ThreeOhApplicator(project: Project) : TaskApplicator(project) {
             if (output is ApkVariantOutput) {
                 // why wouldn't it be?
                 createTask(variant, output.packageApplication, output) { t ->
-                    t.inputFileProperty.set(output.outputFile)
+                    t.inputFileProperty.fileProvider(project.provider { output.outputFile })
                 }
             } else {
                 throw IllegalArgumentException("Unexpected output type for variant ${variant.name}: ${output::class.java}")
@@ -369,7 +369,8 @@ open class ThreeThreeApplicator(project: Project): TaskApplicator(project) {
             }
 
             createTask(variant, packageTask, output) { t ->
-                t.inputFileProperty.set(File(getOutputDirectory(packageTask), output.outputFileName))
+                val fileProvider = project.provider { File(getOutputDirectory(packageTask), output.outputFileName) }
+                t.inputFileProperty.fileProvider(fileProvider)
             }
         }
     }


### PR DESCRIPTION
Release 1.0.0 broke counting of renamed APKs.

In a nutshell this is because of the way Gradle's `DomainObjectCollection<T>#all` method works.  Callbacks given to `all` are executed in the order received, and as a plugin we typically run before the users' `android` blocks are configured.

In 1.0.0, we made a number of changes and inadvertently made configuration of output file names eager, where they had been lazy.  This meant that since we ran before user callbacks, we never saw the renamed APK.

Fixed here by deferring constructing the APK path until the counting task actually runs.

Fixes #291