### PR TITLE
Use ProjectLayout to get a Provider<RegularFile>

### DIFF
--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -370,7 +370,8 @@ open class ThreeThreeApplicator(project: Project): TaskApplicator(project) {
 
             createTask(variant, packageTask, output) { t ->
                 val fileProvider = project.provider { File(getOutputDirectory(packageTask), output.outputFileName) }
-                t.inputFileProperty.fileProvider(fileProvider)
+                val regularFileProvider = project.layout.file(fileProvider)
+                t.inputFileProperty.set(regularFileProvider)
             }
         }
     }


### PR DESCRIPTION
The initial fix for handling renamed APKs inadvertently used an API introduced in Gradle 6.0, breaking our commitment to supporting Gradle 5.1 and above.

There's a less-obvious way to get a `Provider<RegularFile>` via `ProjectLayout`, and that has apparently been available since 4.3.  We'll use that here instead.

Fixes #291 