### PR TITLE
Fix for AGP 4.1 betas

### DIFF
--- a/.buildscript/test.sh
+++ b/.buildscript/test.sh
@@ -23,29 +23,29 @@ function die() {
   exit 1
 }
 
-grep -F 'Total methods in app-debug-it.apk: 7355 (11.22% used)' app.log || die "Incorrect method count in app-debug-it.apk"
-grep -F 'Total fields in app-debug-it.apk:  3780 (5.77% used)' app.log || die "Incorrect field count in app-debug-it.apk"
-grep -F 'Total classes in app-debug-it.apk:  926 (1.41% used)' app.log || die "Incorrect field count in app-debug-it.apk"
-grep -F 'Methods remaining in app-debug-it.apk: 58180' app.log || die "Incorrect remaining-method value in app-debug-it.apk"
-grep -F 'Fields remaining in app-debug-it.apk:  61755' app.log || die "Incorrect remaining-field value in app-debug-it.apk"
-grep -F 'Classes remaining in app-debug-it.apk:  64609' app.log || die "Incorrect remaining-field value in app-debug-it.apk"
+grep -F 'Total methods in app-debug-it.apk: 7356 (11.22% used)' app.log || die "Incorrect method count in app-debug-it.apk"
+grep -F 'Total fields in app-debug-it.apk:  2597 (3.96% used)' app.log || die "Incorrect field count in app-debug-it.apk"
+grep -F 'Total classes in app-debug-it.apk:  441 (0.67% used)' app.log || die "Incorrect field count in app-debug-it.apk"
+grep -F 'Methods remaining in app-debug-it.apk: 58179' app.log || die "Incorrect remaining-method value in app-debug-it.apk"
+grep -F 'Fields remaining in app-debug-it.apk:  62938' app.log || die "Incorrect remaining-field value in app-debug-it.apk"
+grep -F 'Classes remaining in app-debug-it.apk:  65094' app.log || die "Incorrect remaining-field value in app-debug-it.apk"
 
-grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_ClassCount' value='926']" app.log || die "Missing or incorrect Teamcity method count value"
-grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_MethodCount' value='7355']" app.log || die "Missing or incorrect Teamcity method count value"
-grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_FieldCount' value='3780']" app.log || die "Missing or incorrect Teamcity field count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_ClassCount' value='441']" app.log || die "Missing or incorrect Teamcity method count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_MethodCount' value='7356']" app.log || die "Missing or incorrect Teamcity method count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_FieldCount' value='2597']" app.log || die "Missing or incorrect Teamcity field count value"
 
-grep -F 'Total methods in tests-debug.apk: 4265 (6.51% used)' tests.log || die "Incorrect method count in tests-debug.apk"
-grep -F 'Total fields in tests-debug.apk:  1270 (1.94% used)' tests.log || die "Incorrect field count in tests-debug.apk"
+grep -F 'Total methods in tests-debug.apk: 4266 (6.51% used)' tests.log || die "Incorrect method count in tests-debug.apk"
+grep -F 'Total fields in tests-debug.apk:  1268 (1.93% used)' tests.log || die "Incorrect field count in tests-debug.apk"
 grep -F 'Total classes in tests-debug.apk:  723 (1.10% used)' tests.log || die "Incorrect field count in tests-debug.apk"
-grep -F 'Methods remaining in tests-debug.apk: 61270' tests.log || die "Incorrect remaining-method value in tests-debug.apk"
-grep -F 'Fields remaining in tests-debug.apk:  64265' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
+grep -F 'Methods remaining in tests-debug.apk: 61269' tests.log || die "Incorrect remaining-method value in tests-debug.apk"
+grep -F 'Fields remaining in tests-debug.apk:  64267' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
 grep -F 'Classes remaining in tests-debug.apk:  64812' tests.log || die "Incorrect remaining-field value in tests-debug.apk"
 
 grep -F 'Total methods in lib-debug.aar: 7 (0.01% used)' lib.log || die "Incorrect method count in lib-debug.aar"
-grep -F 'Total fields in lib-debug.aar:  5 (0.01% used)' lib.log || die "Incorrect field count in lib-debug.aar"
+grep -F 'Total fields in lib-debug.aar:  3 (0.00% used)' lib.log || die "Incorrect field count in lib-debug.aar"
 grep -F 'Total classes in lib-debug.aar:  5 (0.01% used)' lib.log || die "Incorrect class count in lib-debug.aar"
 grep -F 'Methods remaining in lib-debug.aar: 65528' lib.log || die "Incorrect remaining-method count in lib-debug.aar"
-grep -F 'Fields remaining in lib-debug.aar:  65530' lib.log || die "Incorrect remaining-field count in lib-debug.aar"
+grep -F 'Fields remaining in lib-debug.aar:  65532' lib.log || die "Incorrect remaining-field count in lib-debug.aar"
 grep -F 'Classes remaining in lib-debug.aar:  65530' lib.log || die "Incorrect remaining-class count in lib-debug.aar"
 
 # Note the '&&' here - grep exits with an error if no lines match,

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -28,7 +28,7 @@ ext {
 ext.deps = [
     // Plugins
     "gradle"              : [
-        dependencies.create("com.android.tools.build:gradle:4.0.0") {
+        dependencies.create("com.android.tools.build:gradle:4.1.0-beta01") {
             // Android build tools (as of 3.2.0-alpha18) bundle the deprecated
             // 'jre' stdlib modules, which cause warnings at build-time that
             // fail the build.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
@@ -98,7 +98,7 @@ final class DexMethodCountPluginSpec extends Specification {
           compileSdkVersion 28
 
           defaultConfig {
-            if ("${projectPlugin}" == 'com.android.application') { 
+            if ("${projectPlugin}" == 'com.android.application') {
               applicationId 'com.example'
             }
           }
@@ -203,7 +203,7 @@ final class DexMethodCountPluginSpec extends Specification {
             classpath files($classpathString)
           }
         }
-        
+
         // TODO(???) - Repositories from test
         repositories {
           google()
@@ -225,7 +225,7 @@ final class DexMethodCountPluginSpec extends Specification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir.root)
-            .withArguments("${taskName}")
+            .withArguments("${taskName}", "--full-stacktrace")
             .build()
 
         then:
@@ -249,7 +249,7 @@ final class DexMethodCountPluginSpec extends Specification {
             classpath files($classpathString)
           }
         }
-        
+
         // TODO(???) - Repositories from test
         repositories {
           google()
@@ -265,7 +265,7 @@ final class DexMethodCountPluginSpec extends Specification {
           defaultConfig {
             applicationId 'com.example'
           }
-          
+
           buildTypes {
            debug {}
            release {}
@@ -300,7 +300,7 @@ final class DexMethodCountPluginSpec extends Specification {
             classpath files($classpathString)
           }
         }
-        
+
         // TODO(???) - Repositories from test
         repositories {
           google()
@@ -316,14 +316,14 @@ final class DexMethodCountPluginSpec extends Specification {
           defaultConfig {
             applicationId 'com.example'
           }
-          
+
           buildTypes {
             debug {}
             release {}
           }
-    
+
           flavorDimensions 'a', 'b'
-    
+
           productFlavors {
             flavor1 { dimension 'a' }
             flavor2 { dimension 'a' }
@@ -367,7 +367,7 @@ final class DexMethodCountPluginSpec extends Specification {
             classpath files($classpathString)
           }
         }
-        
+
         // TODO(???) - Repositories from test
         repositories {
           google()
@@ -424,7 +424,7 @@ final class DexMethodCountPluginSpec extends Specification {
             applicationId 'com.example'
           }
         }
-        
+
         dexcount {
           enabled = false
         }


### PR DESCRIPTION
Fixes #298, mostly

This PR fixes two bugs:
1) MissingValueException when trying to read proguard mapping files on builds without obfuscation
2) `IllegalStateException: Extension not initialized yet, couldn't access compileSdkVersion.`

We fix 1 by just disabling deobfuscation.  The API for accessing mapping files is simply broken (see https://issuetracker.google.com/u/1/issues/158379522).

Number 2 is fixed by deferring looking up SDK location until the `afterEvaluate` phase, when whatever internal state is necessary has been set up.