### PR TITLE
Add AGP 4.1 support

### DIFF
--- a/.buildscript/test.sh
+++ b/.buildscript/test.sh
@@ -6,15 +6,15 @@ set -e
 DIR=`pwd`
 trap "cd ${DIR}" SIGINT SIGTERM EXIT
 
-./gradlew clean build publishToMavenLocal --stacktrace --daemon
+./gradlew build publishToMavenLocal --stacktrace --daemon
 
 VERSION=`grep '^VERSION_NAME=' gradle.properties | cut -d '=' -f 2`
 
 echo "Building integration test project..."
 cd integration
-../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :app:assembleDebug 2>&1 --stacktrace | tee app.log
-../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :lib:assembleDebug 2>&1 --stacktrace | tee lib.log
-../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :tests:assembleDebug 2>&1 --stacktrace | tee tests.log
+../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :app:assembleDebug :app:countDebugDexMethods 2>&1 --stacktrace | tee app.log
+../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :lib:assembleDebug :lib:countDebugDexMethods 2>&1 --stacktrace | tee lib.log
+../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :tests:assembleDebug :tests:countDebugDexMethods 2>&1 --stacktrace | tee tests.log
 
 echo "Integration build done!  Running tests..."
 
@@ -23,16 +23,16 @@ function die() {
   exit 1
 }
 
-grep -F 'Total methods in app-debug-it.apk: 7356 (11.22% used)' app.log || die "Incorrect method count in app-debug-it.apk"
-grep -F 'Total fields in app-debug-it.apk:  2597 (3.96% used)' app.log || die "Incorrect field count in app-debug-it.apk"
-grep -F 'Total classes in app-debug-it.apk:  441 (0.67% used)' app.log || die "Incorrect field count in app-debug-it.apk"
-grep -F 'Methods remaining in app-debug-it.apk: 58179' app.log || die "Incorrect remaining-method value in app-debug-it.apk"
-grep -F 'Fields remaining in app-debug-it.apk:  62938' app.log || die "Incorrect remaining-field value in app-debug-it.apk"
-grep -F 'Classes remaining in app-debug-it.apk:  65094' app.log || die "Incorrect remaining-field value in app-debug-it.apk"
+grep -F 'Total methods in app-debug-it.apk: 6725 (10.26% used)' app.log || die "Incorrect method count in app-debug-it.apk"
+grep -F 'Total fields in app-debug-it.apk:  1916 (2.92% used)' app.log || die "Incorrect field count in app-debug-it.apk"
+grep -F 'Total classes in app-debug-it.apk:  837 (1.28% used)' app.log || die "Incorrect field count in app-debug-it.apk"
+grep -F 'Methods remaining in app-debug-it.apk: 58810' app.log || die "Incorrect remaining-method value in app-debug-it.apk"
+grep -F 'Fields remaining in app-debug-it.apk:  63619' app.log || die "Incorrect remaining-field value in app-debug-it.apk"
+grep -F 'Classes remaining in app-debug-it.apk:  64698' app.log || die "Incorrect remaining-field value in app-debug-it.apk"
 
-grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_ClassCount' value='441']" app.log || die "Missing or incorrect Teamcity method count value"
-grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_MethodCount' value='7356']" app.log || die "Missing or incorrect Teamcity method count value"
-grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_FieldCount' value='2597']" app.log || die "Missing or incorrect Teamcity field count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_ClassCount' value='837']" app.log || die "Missing or incorrect Teamcity method count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_MethodCount' value='6725']" app.log || die "Missing or incorrect Teamcity method count value"
+grep -F "##teamcity[buildStatisticValue key='Dexcount_app_debug_FieldCount' value='1916']" app.log || die "Missing or incorrect Teamcity field count value"
 
 grep -F 'Total methods in tests-debug.apk: 4266 (6.51% used)' tests.log || die "Incorrect method count in tests-debug.apk"
 grep -F 'Total fields in tests-debug.apk:  1268 (1.93% used)' tests.log || die "Incorrect field count in tests-debug.apk"
@@ -43,10 +43,10 @@ grep -F 'Classes remaining in tests-debug.apk:  64812' tests.log || die "Incorre
 
 grep -F 'Total methods in lib-debug.aar: 7 (0.01% used)' lib.log || die "Incorrect method count in lib-debug.aar"
 grep -F 'Total fields in lib-debug.aar:  3 (0.00% used)' lib.log || die "Incorrect field count in lib-debug.aar"
-grep -F 'Total classes in lib-debug.aar:  5 (0.01% used)' lib.log || die "Incorrect class count in lib-debug.aar"
+grep -F 'Total classes in lib-debug.aar:  6 (0.01% used)' lib.log || die "Incorrect class count in lib-debug.aar"
 grep -F 'Methods remaining in lib-debug.aar: 65528' lib.log || die "Incorrect remaining-method count in lib-debug.aar"
 grep -F 'Fields remaining in lib-debug.aar:  65532' lib.log || die "Incorrect remaining-field count in lib-debug.aar"
-grep -F 'Classes remaining in lib-debug.aar:  65530' lib.log || die "Incorrect remaining-class count in lib-debug.aar"
+grep -F 'Classes remaining in lib-debug.aar:  65529' lib.log || die "Incorrect remaining-class count in lib-debug.aar"
 
 # Note the '&&' here - grep exits with an error if no lines match,
 # which is the condition we want here.  If any lines match, that

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 *.log
 local.properties
 out/
+.cxx/
+*.hprof

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.getkeepsafe.dexcount
-VERSION_NAME=1.0.4-SNAPSHOT
+VERSION_NAME=2.0.0-SNAPSHOT
 
 POM_ARTIFACT_ID=dexcount-gradle-plugin
 POM_NAME=Dexcount Gradle Plugin

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -28,7 +28,7 @@ ext {
 ext.deps = [
     // Plugins
     "gradle"              : [
-        dependencies.create("com.android.tools.build:gradle:4.1.0-beta01") {
+        dependencies.create("com.android.tools.build:gradle:4.1.0-beta02") {
             // Android build tools (as of 3.2.0-alpha18) bundle the deprecated
             // 'jre' stdlib modules, which cause warnings at build-time that
             // fail the build.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -28,7 +28,7 @@ ext {
 ext.deps = [
     // Plugins
     "gradle"              : [
-        dependencies.create("com.android.tools.build:gradle:4.1.0-beta02") {
+        dependencies.create("com.android.tools.build:gradle:4.1.0-beta03") {
             // Android build tools (as of 3.2.0-alpha18) bundle the deprecated
             // 'jre' stdlib modules, which cause warnings at build-time that
             // fail the build.

--- a/integration/app/CMakeLists.txt
+++ b/integration/app/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10.2)
+
+find_library(log-lib log)
+
+add_library(dummy SHARED src/main/cpp/lib.cpp)
+
+target_link_libraries(dummy ${log-lib})

--- a/integration/app/build.gradle
+++ b/integration/app/build.gradle
@@ -10,6 +10,12 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+
+        externalNativeBuild {
+            cmake {
+                cppFlags "-fno-exceptions"
+            }
+        }
     }
 
     buildTypes {
@@ -20,6 +26,13 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            version "3.10.2"
+            path "CMakeLists.txt"
         }
     }
 

--- a/integration/app/src/main/cpp/lib.cpp
+++ b/integration/app/src/main/cpp/lib.cpp
@@ -1,0 +1,9 @@
+#include <string>
+
+#include <jni.h>
+
+JNIEXPORT jstring JNICALL
+Java_com_getkeepsafe_dexcount_integration_MainActivity_stringFromJNI(JNIEnv* env, jclass clazz)
+{
+  return env->NewStringUTF("Hello from JNI!");
+}

--- a/integration/app/src/main/cpp/lib.cpp
+++ b/integration/app/src/main/cpp/lib.cpp
@@ -1,5 +1,3 @@
-#include <string>
-
 #include <jni.h>
 
 JNIEXPORT jstring JNICALL

--- a/integration/app/src/main/java/com/getkeepsafe/dexcount/integration/MainActivity.java
+++ b/integration/app/src/main/java/com/getkeepsafe/dexcount/integration/MainActivity.java
@@ -5,6 +5,12 @@ import android.os.Bundle;
 
 public class MainActivity extends AppCompatActivity {
 
+    static {
+        System.loadLibrary("dummy");
+    }
+
+    static native String stringFromJNI();
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/integration/lib/build.gradle
+++ b/integration/lib/build.gradle
@@ -26,6 +26,7 @@ android {
 dexcount {
     verbose = true
     teamCitySlug = project.name
+    printDeclarations = true
 }
 
 dependencies {

--- a/src/main/kotlin/com/getkeepsafe/dexcount/ColorConsole.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/ColorConsole.kt
@@ -41,10 +41,16 @@ private enum class Style {
     Error
 }
 
+/**
+ * A thing that can print output, styled based on a given [Color] and [LogLevel].
+ */
 interface Styleable {
     fun withStyledOutput(color: Color = Color.DEFAULT, level: LogLevel? = null, fn: (PrintWriter) -> Unit)
 }
 
+/**
+ * Provides an implementation of [Styleable] backed by a [DefaultTask].
+ */
 class StyleableTaskAdapter(
     private val task: DefaultTask
 ) : Styleable {

--- a/src/main/kotlin/com/getkeepsafe/dexcount/ColorConsole.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/ColorConsole.kt
@@ -41,6 +41,18 @@ private enum class Style {
     Error
 }
 
+interface Styleable {
+    fun withStyledOutput(color: Color = Color.DEFAULT, level: LogLevel? = null, fn: (PrintWriter) -> Unit)
+}
+
+class StyleableTaskAdapter(
+    private val task: DefaultTask
+) : Styleable {
+    override fun withStyledOutput(color: Color, level: LogLevel?, fn: (PrintWriter) -> Unit) {
+        task.withStyledOutput(color, level, fn)
+    }
+}
+
 fun DefaultTask.withStyledOutput(color: Color = Color.DEFAULT, level: LogLevel? = null, fn: (PrintWriter) -> Unit) {
     val style = color.toStyle()
     val factory = this.createStyledOutputFactory()

--- a/src/main/kotlin/com/getkeepsafe/dexcount/CountReporter.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/CountReporter.kt
@@ -5,11 +5,23 @@ import org.gradle.api.logging.LogLevel
 import java.io.File
 import kotlin.math.max
 
+/**
+ * An object that can produce formatted output from a [PackageTree] instance.
+ *
+ * @property packageTree the tree containing the method, field, and class counts to be reported.
+ * @property variantName the name of the variant being counted.
+ * @property outputDir the directory in which to generate reports.
+ * @param styleable a [Styleable] instance with which to print "interactive" reports.
+ * @property config the current dexcount configuration
+ * @property inputRepresentation a string describing the input from which [packageTree] was generated.
+ * @property isAndroidProject true if the input is an APK, AAR, or other Android-related artifact.
+ * @property isInstantRun true if the legacy "Instant Run" feature was used to build the input.
+ */
 class CountReporter(
-    val variantName: String,
     val packageTree: PackageTree,
-    styleable: Styleable,
+    val variantName: String,
     val outputDir: File,
+    styleable: Styleable,
     val config: DexCountExtension,
     val inputRepresentation: String,
     val isAndroidProject: Boolean = true,
@@ -116,7 +128,10 @@ class CountReporter(
 
         if (options.teamCityIntegration || config.teamCitySlug != null) {
             withStyledOutput { out ->
-                val slug = "Dexcount" + (config.teamCitySlug?.let { "_" + it.replace(' ', '_') } ?: "")
+                val slug = "Dexcount" + when (val ts = config.teamCitySlug) {
+                    null -> ""
+                    else -> "_" + ts.replace(' ', '_')
+                }
                 val prefix = "${slug}_${variantName}"
 
                 /**

--- a/src/main/kotlin/com/getkeepsafe/dexcount/CountReporter.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/CountReporter.kt
@@ -1,0 +1,184 @@
+package com.getkeepsafe.dexcount
+
+import org.gradle.api.GradleException
+import org.gradle.api.logging.LogLevel
+import java.io.File
+import kotlin.math.max
+
+class CountReporter(
+    val variantName: String,
+    val packageTree: PackageTree,
+    styleable: Styleable,
+    val outputDir: File,
+    val config: DexCountExtension,
+    val inputRepresentation: String,
+    val isAndroidProject: Boolean = true,
+    val isInstantRun: Boolean = false
+) : Styleable by styleable {
+    private val options = PrintOptions(
+        includeClassCount = config.includeClassCount,
+        includeMethodCount = true,
+        includeFieldCount = config.includeFieldCount,
+        includeTotalMethodCount = config.includeTotalMethodCount,
+        teamCityIntegration = config.teamCityIntegration,
+        orderByMethodCount = config.orderByMethodCount,
+        includeClasses = config.includeClasses,
+        printHeader = true,
+        maxTreeDepth = config.maxTreeDepth,
+        printDeclarations = config.printDeclarations,
+        isAndroidProject = isAndroidProject
+    )
+
+    private val summaryFile = File(outputDir, "summary.csv")
+    private val fullCountFile = File(outputDir, variantName + (config.format as OutputFormat).extension)
+    private val chartDirectory = File(outputDir, "chart")
+
+    fun report() {
+        try {
+            check(config.enabled) { "Tasks should not be executed if the plugin is disabled" }
+
+            printPreamble()
+            printSummary()
+            printFullTree()
+            printChart()
+            printTaskDiagnosticData()
+            failBuildMaxMethods()
+        } catch (e: DexCountException) {
+            withStyledOutput(Color.RED, LogLevel.ERROR) { out ->
+                out.println("Error counting dex methods. Please contact the developer at https://github.com/KeepSafe/dexcount-gradle-plugin/issues")
+                e.printStackTrace(out)
+            }
+        }
+    }
+
+    private fun printPreamble() {
+        if (config.printVersion) {
+            val projectName = javaClass.`package`.implementationTitle
+            val projectVersion = javaClass.`package`.implementationVersion
+
+            withStyledOutput { out ->
+                out.println("Dexcount name:    $projectName")
+                out.println("Dexcount version: $projectVersion")
+                out.println("Dexcount input:   $inputRepresentation")
+            }
+        }
+    }
+
+    private fun printSummary() {
+        if (isInstantRun) {
+            withStyledOutput(Color.RED) { out ->
+                out.println("Warning: Instant Run build detected!  Instant Run does not run Proguard; method counts may be inaccurate.")
+            }
+        }
+
+        val color = if (packageTree.methodCount < 50000) Color.GREEN else Color.YELLOW
+
+        withStyledOutput(color) { out ->
+            fun percentUsed(count: Int): String {
+                val used = (count.toDouble() / MAX_DEX_REFS) * 100.0
+                return String.format("%.2f", used)
+            }
+
+            val percentMethodsUsed = percentUsed(packageTree.methodCount)
+            val percentFieldsUsed = percentUsed(packageTree.fieldCount)
+            val percentClassesUsed = percentUsed(packageTree.classCount)
+
+            val methodsRemaining = max(MAX_DEX_REFS - packageTree.methodCount, 0)
+            val fieldsRemaining = max(MAX_DEX_REFS - packageTree.fieldCount, 0)
+            val classesRemaining = max(MAX_DEX_REFS - packageTree.classCount, 0)
+
+            val (methodCount, fieldCount, classCount) = when {
+                isAndroidProject -> listOf(packageTree.methodCount, packageTree.fieldCount, packageTree.classCount)
+                else -> listOf(packageTree.methodCountDeclared, packageTree.fieldCountDeclared, packageTree.classCountDeclared)
+            }
+
+            out.println("Total methods in $inputRepresentation: $methodCount ($percentMethodsUsed% used)")
+            out.println("Total fields in $inputRepresentation:  $fieldCount ($percentFieldsUsed% used)")
+            out.println("Total classes in $inputRepresentation:  $classCount ($percentClassesUsed% used)")
+
+            if (isAndroidProject) {
+                out.println("Methods remaining in $inputRepresentation: $methodsRemaining")
+                out.println("Fields remaining in $inputRepresentation:  $fieldsRemaining")
+                out.println("Classes remaining in $inputRepresentation:  $classesRemaining")
+            }
+        }
+
+        summaryFile.parentFile.mkdirs()
+        summaryFile.createNewFile()
+
+        val headers = "methods,fields,classes"
+        val counts = "${packageTree.methodCount},${packageTree.fieldCount},${packageTree.classCount}"
+
+        summaryFile.printWriter().use { writer ->
+            writer.println(headers)
+            writer.println(counts)
+        }
+
+        if (options.teamCityIntegration || config.teamCitySlug != null) {
+            withStyledOutput { out ->
+                val slug = "Dexcount" + (config.teamCitySlug?.let { "_" + it.replace(' ', '_') } ?: "")
+                val prefix = "${slug}_${variantName}"
+
+                /**
+                 * Reports to Team City statistic value
+                 * Doc: https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingBuildStatistics
+                 */
+                fun printTeamCityStatisticValue(key: String, value: Int) {
+                    out.println("##teamcity[buildStatisticValue key='${prefix}_${key}' value='$value']")
+                }
+
+                printTeamCityStatisticValue("ClassCount", packageTree.classCount)
+                printTeamCityStatisticValue("MethodCount", packageTree.methodCount)
+                printTeamCityStatisticValue("FieldCount", packageTree.fieldCount)
+            }
+        }
+    }
+
+    private fun printFullTree() {
+        fullCountFile.printStream().use {
+            packageTree.print(it, config.format as OutputFormat, options)
+        }
+    }
+
+    private fun printChart() {
+        options.includeClasses = true
+
+        File(chartDirectory, "data.js").printStream().use { out ->
+            out.print("var data = ")
+            packageTree.printJson(out, options)
+        }
+
+        listOf("chart-builder.js", "d3.v3.min.js", "index.html", "styles.css").forEach { resourceName ->
+            val resource = javaClass.getResourceAsStream("/com/getkeepsafe/dexcount/" + resourceName)
+            val targetFile = File(chartDirectory, resourceName)
+            resource.copyToFile(targetFile)
+        }
+    }
+
+    private fun printTaskDiagnosticData() {
+        // Log the entire package list/tree at LogLevel.DEBUG, unless
+        // verbose is enabled (in which case use the default log level).
+        val level = if (config.verbose) LogLevel.LIFECYCLE else LogLevel.DEBUG
+
+        withStyledOutput(Color.YELLOW, level) { out ->
+            val strBuilder = StringBuilder()
+            packageTree.print(strBuilder, config.format as OutputFormat, options)
+
+            out.format(strBuilder.toString())
+        }
+    }
+
+    private fun failBuildMaxMethods() {
+        if (config.maxMethodCount > 0 && packageTree.methodCount > config.maxMethodCount) {
+            throw GradleException("The current APK has ${packageTree.methodCount} methods, the current max is: ${config.maxMethodCount}.")
+        }
+    }
+
+    companion object {
+        /**
+         * The maximum number of method refs and field refs allowed in a single Dex
+         * file.
+         */
+        const val MAX_DEX_REFS: Int = 0xFFFF // 65535
+    }
+}

--- a/src/main/kotlin/com/getkeepsafe/dexcount/DexCountTask.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/DexCountTask.kt
@@ -16,49 +16,203 @@
 
 package com.getkeepsafe.dexcount
 
+import com.android.build.api.variant.BuiltArtifactsLoader
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import javax.annotation.Nullable
 import javax.inject.Inject
 
-/**
- * The maximum number of method refs and field refs allowed in a single Dex
- * file.
- */
-const val MAX_DEX_REFS: Int = 0xFFFF // 65535
+private inline fun <reified T> ObjectFactory.property(): Property<T> {
+    return property(T::class.java)
+}
 
 @Suppress("UnstableApiUsage")
-open class DexCountTask @Inject constructor(
+abstract class ModernDexCountTask(
+    objects: ObjectFactory
+) : DefaultTask() {
+    @Input
+    val variantNameProperty: Property<String> = objects.property()
+
+    @InputFile
+    @Optional
+    val mappingFileProperty: RegularFileProperty = objects.fileProperty()
+
+    @Internal
+    val loaderProperty: Property<BuiltArtifactsLoader> = objects.property()
+
+    @Nested
+    val configProperty: Property<DexCountExtension> = objects.property()
+
+    @OutputDirectory
+    val outputDirectoryProperty: DirectoryProperty = objects.directoryProperty()
+
+    @get:Internal
+    protected abstract val inputRepresentation: String
+
+    protected abstract fun buildPackageTree(loader: BuiltArtifactsLoader, deobfuscator: Deobfuscator): PackageTree
+
+    @TaskAction
+    open fun execute() {
+        val loader = loaderProperty.get()
+        val deobfuscator = when {
+            mappingFileProperty.isPresent -> Deobfuscator.create(mappingFileProperty.get().asFile)
+            else -> Deobfuscator.empty
+        }
+        val tree = buildPackageTree(loader, deobfuscator)
+
+        val reporter = CountReporter(
+            packageTree = tree,
+            styleable = StyleableTaskAdapter(this),
+            outputDir = outputDirectoryProperty.get().asFile,
+            variantName = variantNameProperty.get(), // builtApks.variantName, <-- this is buggy
+            config = configProperty.get(),
+            inputRepresentation = inputRepresentation,
+            isAndroidProject = true,
+            isInstantRun = false
+        )
+
+        reporter.report()
+    }
+}
+
+@Suppress("UnstableApiUsage")
+open class ApkDexCountTask @Inject constructor(
+    objects: ObjectFactory
+) : ModernDexCountTask(objects) {
+
+    @InputDirectory
+    val apkDirectoryProperty: DirectoryProperty = objects.directoryProperty()
+
+    override var inputRepresentation: String = ""
+
+    override fun buildPackageTree(loader: BuiltArtifactsLoader, deobfuscator: Deobfuscator): PackageTree {
+        val apkDirectory = apkDirectoryProperty.get()
+        val builtApks = checkNotNull(loader.load(apkDirectory))
+        val apkFile = File(builtApks.elements.first().outputFile)
+
+        inputRepresentation = apkFile.name
+
+        val dataList = DexFile.extractDexData(apkFile, configProperty.get().dxTimeoutSec)
+        try {
+            val tree = PackageTree(deobfuscator)
+            for (dexFile in dataList) {
+                for (ref in dexFile.methodRefs) tree.addMethodRef(ref)
+                for (ref in dexFile.fieldRefs) tree.addFieldRef(ref)
+            }
+            return tree
+        } finally {
+            dataList.forEach { it.close() }
+        }
+    }
+}
+
+// This class is so-named because there is no `ArtifactType.AAR` in AGP 4.1,
+// so we have to resort to looking up the bundle task by name, eschewing the
+// new API for the time being.  In 4.2 we'll probably be able to consolidate
+// this and the APK task above.
+@Suppress("UnstableApiUsage")
+open class FourOneLibraryDexCountTask @Inject constructor(
+    objects: ObjectFactory
+) : ModernDexCountTask(objects) {
+
+    @InputFiles
+    val aarBundleFileCollection: ConfigurableFileCollection = objects.fileCollection()
+
+    override var inputRepresentation: String = ""
+
+    override fun buildPackageTree(loader: BuiltArtifactsLoader, deobfuscator: Deobfuscator): PackageTree {
+        if (aarBundleFileCollection.isEmpty) {
+            throw GradleException("Expected")
+        }
+
+        val aar = aarBundleFileCollection.first { it.name.endsWith("aar") }
+        inputRepresentation = aar.name
+
+        val tree = PackageTree(deobfuscator)
+
+        val dataList = DexFile.extractDexData(aar, configProperty.get().dxTimeoutSec)
+        try {
+            for (dexFile in dataList) {
+                for (ref in dexFile.methodRefs) tree.addMethodRef(ref)
+                for (ref in dexFile.fieldRefs) tree.addFieldRef(ref)
+            }
+        } finally {
+            dataList.forEach { it.close() }
+        }
+
+        if (configProperty.get().printDeclarations) {
+            JarFile.extractJarFromAar(aar).use { jar ->
+                for (ref in jar.methodRefs) tree.addDeclaredMethodRef(ref)
+                for (ref in jar.fieldRefs) tree.addDeclaredFieldRef(ref)
+            }
+        }
+
+        return tree
+    }
+}
+
+@Suppress("UnstableApiUsage")
+abstract class JarDexCountTask @Inject constructor (
+    objects: ObjectFactory
+) : DefaultTask() {
+    @InputFile
+    val jarFileProperty: RegularFileProperty = objects.fileProperty()
+
+    @OutputDirectory
+    val outputDirectoryProperty: DirectoryProperty = objects.directoryProperty()
+
+    @Nested
+    val configProperty: Property<DexCountExtension> = objects.property(DexCountExtension::class.java)
+
+    @TaskAction
+    open fun execute() {
+        val tree = PackageTree(Deobfuscator.empty)
+        val jarFile = jarFileProperty.get().asFile
+        JarFile.extractJarFromJar(jarFile).use { jar ->
+            for (ref in jar.methodRefs) tree.addDeclaredMethodRef(ref)
+            for (ref in jar.fieldRefs) tree.addDeclaredFieldRef(ref)
+        }
+
+        val reporter = CountReporter(
+            packageTree = tree,
+            styleable = StyleableTaskAdapter(this),
+            outputDir = outputDirectoryProperty.get().asFile,
+            variantName = "",
+            config = configProperty.get(),
+            inputRepresentation = jarFile.name,
+            isAndroidProject = false,
+            isInstantRun = false
+        )
+
+        reporter.report()
+    }
+}
+
+@Suppress("UnstableApiUsage")
+abstract class LegacyDexCountTask @Inject constructor(
     objects: ObjectFactory
 ): DefaultTask() {
-    private lateinit var tree: PackageTree
-
     /**
      * The output of the 'package' task; will be either an APK or an AAR.
      */
-    private fun getInputFile(): File {
-        return inputFileProperty.asFile.get()
-    }
-
     @InputFile
     val inputFileProperty: RegularFileProperty = objects.fileProperty()
-
-    private val rawInputRepresentation: String
-        get() = "${getInputFile()}"
 
     @Input
     val variantOutputName: Property<String> = objects.property(String::class.java)
@@ -67,107 +221,25 @@ open class DexCountTask @Inject constructor(
     @InputFiles
     val mappingFileProvider: Property<FileCollection> = objects.property(FileCollection::class.java)
 
-    @OutputFile
-    val outputFile: RegularFileProperty = objects.fileProperty()
-
-    @OutputFile
-    val summaryFile: RegularFileProperty = objects.fileProperty()
-
     @OutputDirectory
-    val chartDir: DirectoryProperty = objects.directoryProperty()
+    val outputDirectoryProperty: DirectoryProperty = objects.directoryProperty()
 
     @Nested
-    lateinit var config: DexCountExtension
-
-    private var startTime   = 0L
-    private var ioTime      = 0L
-    private var treegenTime = 0L
-    private var outputTime  = 0L
-
-    private val printOptions by lazy { // needs to be lazy because config is lateinit
-        PrintOptions(
-            includeClassCount = config.includeClassCount,
-            includeMethodCount = true,
-            includeFieldCount = config.includeFieldCount,
-            includeTotalMethodCount = config.includeTotalMethodCount,
-            teamCityIntegration = config.teamCityIntegration,
-            orderByMethodCount = config.orderByMethodCount,
-            includeClasses = config.includeClasses,
-            printHeader = true,
-            maxTreeDepth = config.maxTreeDepth,
-            printDeclarations = config.printDeclarations,
-            isAndroidProject = isAndroidProject
-        )
-    }
-
-    private val deobfuscator by lazy {
-        val fileCollection = mappingFileProvider.orNull ?: return@lazy Deobfuscator.empty
-        val file = fileCollection.singleOrNull() ?: return@lazy Deobfuscator.empty
-        if (file.exists()) {
-            Deobfuscator.create(file)
-        } else {
-            withStyledOutput(level = LogLevel.DEBUG) {
-                it.println("Mapping file specified at ${file.absolutePath} does not exist, assuming output is not obfuscated.")
-            }
-            Deobfuscator.empty
-        }
-    }
-
-    private var isInstantRun = false
-    private var isAndroidProject = true
+    val configProperty: Property<DexCountExtension> = objects.property()
 
     @TaskAction
     open fun execute() {
-        try {
-            check(config.enabled) { "Tasks should not be executed if the plugin is disabled" }
+        val config = configProperty.get()
+        val deobfuscator = Deobfuscator.create(mappingFileProvider.orNull?.singleOrNull())
 
-            if (!getInputFile().exists()) {
-                return
-            }
-
-            printPreamble()
-            generatePackageTree()
-            printSummary()
-            printFullTree()
-            printChart()
-            printTaskDiagnosticData()
-            failBuildMaxMethods()
-        } catch (e: DexCountException) {
-            withStyledOutput(Color.RED, LogLevel.ERROR) { out ->
-                out.println("Error counting dex methods. Please contact the developer at https://github.com/KeepSafe/dexcount-gradle-plugin/issues")
-                e.printStackTrace(out)
-            }
-        }
-    }
-
-    private fun printPreamble() {
-        if (config.printVersion) {
-            val projectName = javaClass.`package`.implementationTitle
-            val projectVersion = javaClass.`package`.implementationVersion
-
-            withStyledOutput { out ->
-                out.println("Dexcount name:    $projectName")
-                out.println("Dexcount version: $projectVersion")
-                out.println("Dexcount input:   $rawInputRepresentation")
-            }
-        }
-    }
-
-    /**
-     * Creates a new PackageTree and populates it with the method and field
-     * counts of the current dex/apk file.
-     */
-    private fun generatePackageTree() {
-        val file = getInputFile()
+        val file = inputFileProperty.get().asFile
 
         val isApk = file.extension == "apk"
         val isAar = file.extension == "aar"
         val isJar = file.extension == "jar"
-        isAndroidProject = isAar || isApk
+        val isAndroidProject = isAar || isApk
 
         check(isApk || isAar || isJar) { "File extension is unclear: $file" }
-
-        startTime = System.currentTimeMillis()
 
         val dataList = if (isAndroidProject) DexFile.extractDexData(file, config.dxTimeoutSec) else emptyList()
         val jarFile = when {
@@ -176,7 +248,7 @@ open class DexCountTask @Inject constructor(
             else -> null
         }
 
-        ioTime = System.currentTimeMillis()
+        val tree: PackageTree
         try {
             tree = PackageTree(deobfuscator)
 
@@ -192,148 +264,17 @@ open class DexCountTask @Inject constructor(
             jarFile?.close()
         }
 
-        treegenTime = System.currentTimeMillis()
+        val reporter = CountReporter(
+            variantName = variantOutputName.get(),
+            packageTree = tree,
+            styleable = StyleableTaskAdapter(this),
+            outputDir = outputDirectoryProperty.get().asFile,
+            config = config,
+            inputRepresentation = file.name,
+            isAndroidProject = isAndroidProject,
+            isInstantRun = dataList.any { it.isInstantRun }
+        )
 
-        isInstantRun = dataList.any { it.isInstantRun }
-    }
-
-    /**
-     * Prints a summary of method and field counts
-     * @return
-     */
-    private fun printSummary() {
-        val filename = getInputFile().name
-
-        if (isInstantRun) {
-            withStyledOutput(Color.RED) { out ->
-                out.println("Warning: Instant Run build detected!  Instant Run does not run Proguard; method counts may be inaccurate.")
-            }
-        }
-
-        val color = if (tree.methodCount < 50000) Color.GREEN else Color.YELLOW
-
-        withStyledOutput(color) { out ->
-            fun percentUsed(count: Int): String {
-                val used = (count.toDouble() / MAX_DEX_REFS) * 100.0
-                return String.format("%.2f", used)
-            }
-
-            val percentMethodsUsed = percentUsed(tree.methodCount)
-            val percentFieldsUsed = percentUsed(tree.fieldCount)
-            val percentClassesUsed = percentUsed(tree.classCount)
-
-            val methodsRemaining = Math.max(MAX_DEX_REFS - tree.methodCount, 0)
-            val fieldsRemaining = Math.max(MAX_DEX_REFS - tree.fieldCount, 0)
-            val classesRemaining = Math.max(MAX_DEX_REFS - tree.classCount, 0)
-
-            if (isAndroidProject) {
-                out.println("Total methods in $filename: ${tree.methodCount} ($percentMethodsUsed% used)")
-                out.println("Total fields in $filename:  ${tree.fieldCount} ($percentFieldsUsed% used)")
-                out.println("Total classes in $filename:  ${tree.classCount} ($percentClassesUsed% used)")
-                out.println("Methods remaining in $filename: $methodsRemaining")
-                out.println("Fields remaining in $filename:  $fieldsRemaining")
-                out.println("Classes remaining in $filename:  $classesRemaining")
-            } else {
-                out.println("Total methods in $filename: ${tree.methodCountDeclared} ($percentMethodsUsed% used)")
-                out.println("Total fields in $filename:  ${tree.fieldCountDeclared} ($percentFieldsUsed% used)")
-                out.println("Total classes in $filename:  ${tree.classCountDeclared} ($percentClassesUsed% used)")
-            }
-        }
-
-        summaryFile.get().asFile.parentFile.mkdirs()
-        summaryFile.get().asFile.createNewFile()
-
-        val headers = "methods,fields,classes"
-        val counts = "${tree.methodCount},${tree.fieldCount},${tree.classCount}"
-
-        summaryFile.get().asFile.printWriter().use { writer ->
-            writer.println(headers)
-            writer.println(counts)
-        }
-
-        if (printOptions.teamCityIntegration || config.teamCitySlug != null) {
-            withStyledOutput { out ->
-                val slug = "Dexcount" + (config.teamCitySlug?.let { "_" + it.replace(' ', '_') } ?: "")
-                val prefix = "${slug}_${variantOutputName.get()}"
-
-                /**
-                 * Reports to Team City statistic value
-                 * Doc: https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingBuildStatistics
-                 */
-                fun printTeamCityStatisticValue(key: String, value: Int) {
-                    out.println("##teamcity[buildStatisticValue key='${prefix}_${key}' value='$value']")
-                }
-
-                printTeamCityStatisticValue("ClassCount", tree.classCount)
-                printTeamCityStatisticValue("MethodCount", tree.methodCount)
-                printTeamCityStatisticValue("FieldCount", tree.fieldCount)
-            }
-        }
-    }
-
-    /**
-     * Prints the package tree to the usual outputs/dexcount/variant.txt file.
-     */
-    private fun printFullTree() {
-        outputFile.get().asFile.printStream().use(this::printTreeToAppendable)
-        outputTime = System.currentTimeMillis()
-    }
-
-    /**
-     * Prints the package tree as chart to the outputs/dexcount/${variant}Chart directory.
-     */
-    private fun printChart() {
-        val printOptions = printOptions
-        printOptions.includeClasses = true
-
-        val directory = chartDir.get().asFile
-        File(directory, "data.js").printStream().use { out ->
-            out.print("var data = ")
-            tree.printJson(out, printOptions)
-        }
-
-        listOf("chart-builder.js", "d3.v3.min.js", "index.html", "styles.css").forEach { resourceName ->
-            val resource = javaClass.getResourceAsStream("/com/getkeepsafe/dexcount/" + resourceName)
-            val targetFile = File(directory, resourceName)
-            resource.copyToFile(targetFile)
-        }
-    }
-
-    /**
-     * Logs the package tree to stdout at {@code LogLevel.DEBUG}, or at the
-     * default level if verbose-mode is configured.
-     */
-    private fun printTaskDiagnosticData() {
-        // Log the entire package list/tree at LogLevel.DEBUG, unless
-        // verbose is enabled (in which case use the default log level).
-        val level = if (config.verbose) LogLevel.LIFECYCLE else LogLevel.DEBUG
-
-        withStyledOutput(Color.YELLOW, level) { out ->
-            val strBuilder = StringBuilder()
-            printTreeToAppendable(strBuilder)
-
-            out.format(strBuilder.toString())
-            out.format("\n\nTask runtimes:")
-            out.format("--------------")
-            out.format("parsing:    ${ioTime - startTime} ms")
-            out.format("counting:   ${treegenTime - ioTime} ms")
-            out.format("printing:   ${outputTime - treegenTime} ms")
-            out.format("total:      ${outputTime - startTime} ms")
-            out.format("")
-            out.format("input:      {}", rawInputRepresentation)
-        }
-    }
-
-    /**
-     * Fails the build when a user specifies a "max method count" for their current build.
-     */
-    private fun failBuildMaxMethods() {
-        if (config.maxMethodCount > 0 && tree.methodCount > config.maxMethodCount) {
-            throw GradleException("The current APK has ${tree.methodCount} methods, the current max is: ${config.maxMethodCount}.")
-        }
-    }
-
-    private fun printTreeToAppendable(out: Appendable) {
-        tree.print(out, config.format as OutputFormat, printOptions)
+        reporter.report()
     }
 }

--- a/src/main/kotlin/com/getkeepsafe/dexcount/DexCountTask.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/DexCountTask.kt
@@ -78,9 +78,9 @@ abstract class ModernDexCountTask(
 
         val reporter = CountReporter(
             packageTree = tree,
-            styleable = StyleableTaskAdapter(this),
+            variantName = variantNameProperty.get(),
             outputDir = outputDirectoryProperty.get().asFile,
-            variantName = variantNameProperty.get(), // builtApks.variantName, <-- this is buggy
+            styleable = StyleableTaskAdapter(this), // builtApks.variantName, <-- this is buggy
             config = configProperty.get(),
             inputRepresentation = inputRepresentation,
             isAndroidProject = true,
@@ -178,7 +178,7 @@ abstract class JarDexCountTask @Inject constructor (
     val outputDirectoryProperty: DirectoryProperty = objects.directoryProperty()
 
     @Nested
-    val configProperty: Property<DexCountExtension> = objects.property(DexCountExtension::class.java)
+    val configProperty: Property<DexCountExtension> = objects.property()
 
     @TaskAction
     open fun execute() {
@@ -191,9 +191,9 @@ abstract class JarDexCountTask @Inject constructor (
 
         val reporter = CountReporter(
             packageTree = tree,
-            styleable = StyleableTaskAdapter(this),
-            outputDir = outputDirectoryProperty.get().asFile,
             variantName = "",
+            outputDir = outputDirectoryProperty.get().asFile,
+            styleable = StyleableTaskAdapter(this),
             config = configProperty.get(),
             inputRepresentation = jarFile.name,
             isAndroidProject = false,
@@ -215,11 +215,11 @@ abstract class LegacyDexCountTask @Inject constructor(
     val inputFileProperty: RegularFileProperty = objects.fileProperty()
 
     @Input
-    val variantOutputName: Property<String> = objects.property(String::class.java)
+    val variantOutputName: Property<String> = objects.property()
 
     @Nullable
     @InputFiles
-    val mappingFileProvider: Property<FileCollection> = objects.property(FileCollection::class.java)
+    val mappingFileProvider: Property<FileCollection> = objects.property()
 
     @OutputDirectory
     val outputDirectoryProperty: DirectoryProperty = objects.directoryProperty()
@@ -265,10 +265,10 @@ abstract class LegacyDexCountTask @Inject constructor(
         }
 
         val reporter = CountReporter(
-            variantName = variantOutputName.get(),
             packageTree = tree,
-            styleable = StyleableTaskAdapter(this),
+            variantName = variantOutputName.get(),
             outputDir = outputDirectoryProperty.get().asFile,
+            styleable = StyleableTaskAdapter(this),
             config = config,
             inputRepresentation = file.name,
             isAndroidProject = isAndroidProject,

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexCountExtensionSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexCountExtensionSpec.groovy
@@ -16,6 +16,9 @@
 
 package com.getkeepsafe.dexcount
 
+import com.android.build.api.variant.BuiltArtifact
+import com.android.build.api.variant.BuiltArtifacts
+import com.android.build.api.variant.BuiltArtifactsLoader
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
@@ -28,6 +31,10 @@ final class DexCountExtensionSpec extends Specification {
     @Rule TemporaryFolder temporaryFolder = new TemporaryFolder()
     private Project project
     private File apkFile
+
+    private BuiltArtifact apkArtifact
+    private BuiltArtifacts builtArtifacts
+    private BuiltArtifactsLoader loader
 
     def "setup"() {
         project = ProjectBuilder.builder().build()
@@ -46,6 +53,14 @@ final class DexCountExtensionSpec extends Specification {
         apkResource.withStream { input ->
             apkFile.append(input)
         }
+
+        apkArtifact = Mock()
+        builtArtifacts = Mock()
+        loader = Mock()
+
+        apkArtifact.outputFile >> apkFile.canonicalPath
+        builtArtifacts.elements >> [apkArtifact]
+        loader.load(_) >> builtArtifacts
     }
 
     def "maxMethodCount methods < tiles.apk methods, throw exception"() {
@@ -67,9 +82,10 @@ final class DexCountExtensionSpec extends Specification {
         project.evaluate()
 
         // Override APK file
-        DexCountTask task = project.tasks.getByName("countDebugDexMethods") as DexCountTask
-        task.variantOutputName.set("extensionSpec")
-        task.inputFileProperty.set(apkFile)
+        ApkDexCountTask task = project.tasks.getByName("countDebugDexMethods") as ApkDexCountTask
+        task.variantNameProperty.set("extensionSpec")
+        task.apkDirectoryProperty.set(apkFile.parentFile)
+        task.loaderProperty.set(loader)
         task.execute()
 
         then:
@@ -95,9 +111,10 @@ final class DexCountExtensionSpec extends Specification {
         project.evaluate()
 
         // Override APK file
-        DexCountTask task = project.tasks.getByName("countDebugDexMethods") as DexCountTask
-        task.variantOutputName.set("extensionSpec")
-        task.inputFileProperty.set(apkFile)
+        ApkDexCountTask task = project.tasks.getByName("countDebugDexMethods") as ApkDexCountTask
+        task.variantNameProperty.set("extensionSpec")
+        task.apkDirectoryProperty.set(apkFile.parentFile)
+        task.loaderProperty.set(loader)
         task.execute()
 
         then:
@@ -124,9 +141,10 @@ final class DexCountExtensionSpec extends Specification {
         project.evaluate()
 
         // Override APK file
-        DexCountTask task = project.tasks.getByName("countDebugDexMethods") as DexCountTask
-        task.variantOutputName.set("extensionSpec")
-        task.inputFileProperty.set(apkFile)
+        ApkDexCountTask task = project.tasks.getByName("countDebugDexMethods") as ApkDexCountTask
+        task.variantNameProperty.set("extensionSpec")
+        task.apkDirectoryProperty.set(apkFile.parentFile)
+        task.loaderProperty.set(loader)
         task.execute()
 
         then:


### PR DESCRIPTION
This absurdly-large PR adds essentially a brand-new plugin implementation using the new APIs introduced in AGP 4.1.0.  For various reasons this requires breaking back-compat in terms of the names and locations of output files on older AGP versions.  (tl;dr: not possible to replicate the exact layout in the new API, and it's better to have a consistent format rather than vary it based on AGP version).

Fixes #301 
