### PR TITLE
Add support for counting app bundles

### DIFF
--- a/.buildscript/test.sh
+++ b/.buildscript/test.sh
@@ -12,9 +12,10 @@ VERSION=`grep '^VERSION_NAME=' gradle.properties | cut -d '=' -f 2`
 
 echo "Building integration test project..."
 cd integration
-../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :app:assembleDebug :app:countDebugDexMethods 2>&1 --stacktrace | tee app.log
-../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :lib:assembleDebug :lib:countDebugDexMethods 2>&1 --stacktrace | tee lib.log
-../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :tests:assembleDebug :tests:countDebugDexMethods 2>&1 --stacktrace | tee tests.log
+../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :app:countDebugDexMethods 2>&1 --stacktrace | tee app.log
+../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :lib:countDebugDexMethods 2>&1 --stacktrace | tee lib.log
+../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :tests:countDebugDexMethods 2>&1 --stacktrace | tee tests.log
+../gradlew --daemon clean -PdexcountVersion="$VERSION" -Pandroid.debug.obsoleteApi=true :app:countDebugBundleDexMethods 2>&1 --stacktrace | tee bundle.log
 
 echo "Integration build done!  Running tests..."
 
@@ -47,6 +48,10 @@ grep -F 'Total classes in lib-debug.aar:  6 (0.01% used)' lib.log || die "Incorr
 grep -F 'Methods remaining in lib-debug.aar: 65528' lib.log || die "Incorrect remaining-method count in lib-debug.aar"
 grep -F 'Fields remaining in lib-debug.aar:  65532' lib.log || die "Incorrect remaining-field count in lib-debug.aar"
 grep -F 'Classes remaining in lib-debug.aar:  65529' lib.log || die "Incorrect remaining-class count in lib-debug.aar"
+
+grep -F 'Total methods in app-debug.aab: 6725 (10.26% used)' bundle.log || die "Incorrect method count in app-debug.aab"
+grep -F 'Total fields in app-debug.aab:  1916 (2.92% used)' bundle.log || die "Incorrect field count in app-debug.aab"
+grep -F 'Total classes in app-debug.aab:  837 (1.28% used)' bundle.log || die "Incorrect field count in app-debug.aab"
 
 # Note the '&&' here - grep exits with an error if no lines match,
 # which is the condition we want here.  If any lines match, that

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -442,6 +442,7 @@ open class FourOneApplicator(ext: DexCountExtension, project: Project) : Abstrac
             val android = project.extensions.getByType(ApplicationExtension::class.java)
             android.onVariantProperties {
                 registerApkTask()
+                registerAabTask()
             }
         }
 
@@ -480,6 +481,25 @@ open class FourOneApplicator(ext: DexCountExtension, project: Project) : Abstrac
             t.configProperty.set(ext)
             t.variantNameProperty.set(name)
             t.apkDirectoryProperty.set(artifacts.get(ArtifactType.APK))
+            t.loaderProperty.set(artifacts.getBuiltArtifactsLoader())
+            t.mappingFileProperty.set(artifacts.get(ArtifactType.OBFUSCATION_MAPPING_FILE))
+            t.outputDirectoryProperty.set(project.layout.buildDirectory.dir("outputs/dexcount/$name"))
+        }
+    }
+
+    protected open fun VariantProperties.registerAabTask() {
+        if (!ext.enabled) {
+            return
+        }
+
+        check(!ext.printDeclarations) { "Cannot compute declarations for project $project" }
+
+        val taskName = "count${name.capitalize()}BundleDexMethods"
+
+        project.tasks.register<ApkDexCountTask>(taskName) { t ->
+            t.configProperty.set(ext)
+            t.variantNameProperty.set(name)
+            t.bundleFileProperty.set(artifacts.get(ArtifactType.BUNDLE))
             t.loaderProperty.set(artifacts.getBuiltArtifactsLoader())
             t.mappingFileProperty.set(artifacts.get(ArtifactType.OBFUSCATION_MAPPING_FILE))
             t.outputDirectoryProperty.set(project.layout.buildDirectory.dir("outputs/dexcount/$name"))

--- a/src/main/kotlin/com/getkeepsafe/dexcount/SourceFile.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/SourceFile.kt
@@ -186,7 +186,7 @@ internal class DexFile(
         fun extractDexFromZip(file: File): List<DexFile> {
             return file.unzip { entries ->
                 entries
-                    .filter { it.name.matches(Regex("classes.*\\.dex")) }
+                    .filter { it.name.matches(Regex("(.*/)*classes.*\\.dex")) }
                     .map { entry ->
                         val temp = makeTempFile("dexcount.dex")
                         entry.writeTo(temp)


### PR DESCRIPTION
This PR adds a new task `count<Variant>BundleDexMethods` in projects using AGP 4.1.0+.  It also opens the _possibility_ of supporting .aab counting in earlier versions, since all that we really needed was a tweak in the regex for extracting .dex files from zip archives.  TBD on whether I actually get around to "backporting" AAB support.

Fixes #250