### PR TITLE
Various small cleanups and refactorings following the big split

### DIFF
--- a/src/main/kotlin/com/getkeepsafe/dexcount/CountReporter.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/CountReporter.kt
@@ -24,19 +24,7 @@ class CountReporter(
     val isAndroidProject: Boolean = true,
     val isInstantRun: Boolean = false
 ) : Styleable by styleable {
-    private val options = PrintOptions(
-        includeClassCount = config.includeClassCount,
-        includeMethodCount = true,
-        includeFieldCount = config.includeFieldCount,
-        includeTotalMethodCount = config.includeTotalMethodCount,
-        teamCityIntegration = config.teamCityIntegration,
-        orderByMethodCount = config.orderByMethodCount,
-        includeClasses = config.includeClasses,
-        printHeader = true,
-        maxTreeDepth = config.maxTreeDepth,
-        printDeclarations = config.printDeclarations,
-        isAndroidProject = isAndroidProject
-    )
+    private val options = config.toPrintOptions(isAndroidProject)
 
     fun report() {
         try {

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -218,7 +218,7 @@ abstract class LegacyTaskApplicator(ext: DexCountExtension, project: Project) : 
             t.group       = "Reporting"
 
             t.configProperty.set(ext)
-            t.variantNameProperty.set("")
+            t.outputFileNameProperty.set(jarTask.archiveFile.map { it.asFile.nameWithoutExtension })
             t.jarFileProperty.set(jarTask.archiveFile)
             t.packageTreeFileProperty.set(project.layout.buildDirectory.file("intermediates/dexcount/tree.compact.gz"))
             t.outputDirectoryProperty.set(project.layout.buildDirectory.dir("outputs/dexcount"))
@@ -273,7 +273,7 @@ abstract class LegacyTaskApplicator(ext: DexCountExtension, project: Project) : 
             t.group               = "Reporting"
 
             t.configProperty.set(ext)
-            t.variantNameProperty.set(outputName)
+            t.outputFileNameProperty.set(outputName)
             t.mappingFileProvider.set(getMappingFile(variant))
             t.outputDirectoryProperty.set(project.file(path))
             t.packageTreeFileProperty.set(project.layout.buildDirectory.file(treePath))
@@ -514,7 +514,7 @@ open class FourOneApplicator(ext: DexCountExtension, project: Project) : Abstrac
             t.group       = "Reporting"
 
             t.configProperty.set(ext)
-            t.variantNameProperty.set(name)
+            t.outputFileNameProperty.set(name)
             t.apkDirectoryProperty.set(artifacts.get(ArtifactType.APK))
             t.loaderProperty.set(artifacts.getBuiltArtifactsLoader())
             t.mappingFileProperty.set(artifacts.get(ArtifactType.OBFUSCATION_MAPPING_FILE))
@@ -547,7 +547,7 @@ open class FourOneApplicator(ext: DexCountExtension, project: Project) : Abstrac
             t.group       = "Reporting"
 
             t.configProperty.set(ext)
-            t.variantNameProperty.set(name)
+            t.outputFileNameProperty.set(name)
             t.bundleFileProperty.set(artifacts.get(ArtifactType.BUNDLE))
             t.loaderProperty.set(artifacts.getBuiltArtifactsLoader())
             t.mappingFileProperty.set(artifacts.get(ArtifactType.OBFUSCATION_MAPPING_FILE))
@@ -584,7 +584,7 @@ open class FourOneApplicator(ext: DexCountExtension, project: Project) : Abstrac
                 t.group       = "Reporting"
 
                 t.configProperty.set(ext)
-                t.variantNameProperty.set(name)
+                t.outputFileNameProperty.set(name)
                 t.aarBundleFileCollection.from(bundleTaskProvider)
                 t.loaderProperty.set(artifacts.getBuiltArtifactsLoader())
                 t.mappingFileProperty.set(artifacts.get(ArtifactType.OBFUSCATION_MAPPING_FILE))
@@ -622,7 +622,7 @@ open class FourOneApplicator(ext: DexCountExtension, project: Project) : Abstrac
             t.group       = "Reporting"
 
             t.configProperty.set(ext)
-            t.variantNameProperty.set("")
+            t.outputFileNameProperty.set(jarTaskProvider.flatMap { jarTask -> jarTask.archiveFile.map { it.asFile.nameWithoutExtension } })
             t.jarFileProperty.set(jarTaskProvider.flatMap { it.archiveFile })
             t.packageTreeFileProperty.set(project.layout.buildDirectory.file("intermediates/dexcount/tree.compact.gz"))
             t.outputDirectoryProperty.set(project.layout.buildDirectory.dir("outputs/dexcount"))

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexCountExtensionSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexCountExtensionSpec.groovy
@@ -83,7 +83,7 @@ final class DexCountExtensionSpec extends Specification {
 
         // Override APK file
         ApkPackageTreeTask task = project.tasks.getByName("generateDebugPackageTree") as ApkPackageTreeTask
-        task.variantNameProperty.set("extensionSpec")
+        task.outputFileNameProperty.set("extensionSpec")
         task.apkDirectoryProperty.set(apkFile.parentFile)
         task.loaderProperty.set(loader)
         task.execute()
@@ -115,7 +115,7 @@ final class DexCountExtensionSpec extends Specification {
 
         // Override APK file
         ApkPackageTreeTask task = project.tasks.getByName("generateDebugPackageTree") as ApkPackageTreeTask
-        task.variantNameProperty.set("extensionSpec")
+        task.outputFileNameProperty.set("extensionSpec")
         task.apkDirectoryProperty.set(apkFile.parentFile)
         task.loaderProperty.set(loader)
         task.execute()
@@ -145,7 +145,7 @@ final class DexCountExtensionSpec extends Specification {
 
         // Override APK file
         ApkPackageTreeTask task = project.tasks.getByName("generateDebugPackageTree") as ApkPackageTreeTask
-        task.variantNameProperty.set("extensionSpec")
+        task.outputFileNameProperty.set("extensionSpec")
         task.apkDirectoryProperty.set(apkFile.parentFile)
         task.loaderProperty.set(loader)
         task.execute()

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexMethodCountPluginSpec.groovy
@@ -441,7 +441,7 @@ final class DexMethodCountPluginSpec extends Specification {
 
         // Override APK file
         ApkPackageTreeTask task = project.tasks.getByName("generateDebugPackageTree") as ApkPackageTreeTask
-        task.variantNameProperty.set("pluginSpec")
+        task.outputFileNameProperty.set("pluginSpec")
         task.apkDirectoryProperty.set(apkFile.parentFile)
         task.loaderProperty.set(loader)
         task.execute()


### PR DESCRIPTION
- Make all instantiations of `PrintOptions` in the plugin use the new factory extension function on `DexCountExtension`.

- Rename `BaseGeneratePackageTreeTask#variantNameProperty` -> `outputFileNameProperty`, because
    a) that's all the property is used for
    b) jars don't have variants

- Provide `outputFileNameProperty` values for jar-counting tasks derived from the counted jar's filename.

- Use a Gradle Provider for getting Deobfuscators rather than a kotlin lazy val; this ought to be slightly more future-proof against lifecycle bugs, since in theory it should respond to the underlying property providing the mapping file.

- Document at least the base task's inputs and outputs.