### PR TITLE
Upgrade to Spock 2.0-M3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,10 +74,13 @@ dependencies {
 
     testImplementation "org.codehaus.groovy:groovy-all:2.5.13"
     testImplementation "com.android.tools.build:gradle:$agpVersion"
-    testImplementation "junit:junit:4.13"
-    testImplementation dependencies.create("org.spockframework:spock-core:1.3-groovy-2.5") {
+    testImplementation dependencies.create("org.spockframework:spock-core:2.0-M3-groovy-2.5") {
         exclude module: "groovy-all"
     }
+}
+
+test {
+    useJUnitPlatform()
 }
 
 tasks {

--- a/src/test/groovy/com/getkeepsafe/dexcount/DeobfuscatorSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DeobfuscatorSpec.groovy
@@ -16,13 +16,9 @@
 
 package com.getkeepsafe.dexcount
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
 final class DeobfuscatorSpec extends Specification {
-    @Rule TemporaryFolder temporaryFolder = new TemporaryFolder()
-
     def "when no mapping file exists, returns given classnames unaltered"() {
         given:
         def deobs = Deobfuscator.create(null)
@@ -38,7 +34,7 @@ final class DeobfuscatorSpec extends Specification {
 
     def "maps proguarded names to original names"() {
         given:
-        File file = temporaryFolder.newFile()
+        File file = File.createTempFile("tmp", ".map")
         file.withPrintWriter {
             // Proguard mapping for classnames is "old -> new:"
             it.println("com.foo.Bar -> a:")
@@ -54,6 +50,9 @@ final class DeobfuscatorSpec extends Specification {
         then:
         classOne == "com.foo.Bar"
         classTwo == "com.baz.Quux"
+
+        cleanup:
+        file.delete()
     }
 }
 

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexCountExtensionSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexCountExtensionSpec.groovy
@@ -23,12 +23,9 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
 final class DexCountExtensionSpec extends Specification {
-    @Rule TemporaryFolder temporaryFolder = new TemporaryFolder()
     private Project project
     private File apkFile
 
@@ -48,7 +45,7 @@ final class DexCountExtensionSpec extends Specification {
           </manifest>
         """)
 
-        apkFile = temporaryFolder.newFile("tiles.apk")
+        apkFile = File.createTempFile("tiles", ".apk")
         def apkResource = getClass().getResourceAsStream("/tiles.apk")
         apkResource.withStream { input ->
             apkFile.append(input)
@@ -61,6 +58,10 @@ final class DexCountExtensionSpec extends Specification {
         apkArtifact.outputFile >> apkFile.canonicalPath
         builtArtifacts.elements >> [apkArtifact]
         loader.load(_) >> builtArtifacts
+    }
+
+    def "cleanup"() {
+        apkFile.delete()
     }
 
     def "maxMethodCount methods < tiles.apk methods, throw exception"() {

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexFileSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexFileSpec.groovy
@@ -16,13 +16,9 @@
 
 package com.getkeepsafe.dexcount
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
 final class DexFileSpec extends Specification {
-    @Rule TemporaryFolder temporaryFolder = new TemporaryFolder()
-
     def "test AAR dexcount"() {
         given:
         if (new File("local.properties").exists()) {
@@ -35,7 +31,7 @@ final class DexFileSpec extends Specification {
             DexMethodCountPlugin.sdkLocation = new File(System.getenv("ANDROID_HOME"))
         }
 
-        def aarFile = temporaryFolder.newFile("test.aar")
+        def aarFile = File.createTempFile("test", ".aar")
 
         getClass().getResourceAsStream('/android-beacon-library-2.7.aar').withStream { input ->
             aarFile.append(input)
@@ -49,11 +45,14 @@ final class DexFileSpec extends Specification {
         dexFiles.size() == 1
         dexFiles[0].methodRefs.size() == 982
         dexFiles[0].fieldRefs.size() == 436
+
+        cleanup:
+        aarFile.delete()
     }
 
     def "test APK built with tools v24"() {
         given:
-        def apk = temporaryFolder.newFile("app-debug-tools-v24.apk")
+        def apk = File.createTempFile("app-debug-tools-v24", ".apk")
 
         getClass().getResourceAsStream("/app-debug-tools-v24.apk").withStream { input ->
             apk.append(input)
@@ -67,5 +66,8 @@ final class DexFileSpec extends Specification {
         dexFiles.size() == 2
         dexFiles[0].methodRefs.size() == 3
         dexFiles[1].methodRefs.size() == 297
+
+        cleanup:
+        apk.delete()
     }
 }

--- a/src/test/groovy/com/getkeepsafe/dexcount/JarFileSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/JarFileSpec.groovy
@@ -16,16 +16,12 @@
 
 package com.getkeepsafe.dexcount
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
 final class JarFileSpec extends Specification {
-    @Rule TemporaryFolder temporaryFolder = new TemporaryFolder()
-
     def "test AAR method count"() {
         given:
-        def aarFile = temporaryFolder.newFile("test.aar")
+        def aarFile = File.createTempFile("test", ".aar")
 
         getClass().getResourceAsStream('/android-beacon-library-2.7.aar').withStream { input ->
             aarFile.append(input)
@@ -38,5 +34,8 @@ final class JarFileSpec extends Specification {
         jarFile != null
         jarFile.methodRefs.size() == 659
         jarFile.fieldRefs.size() == 405
+
+        cleanup:
+        aarFile.delete()
     }
 }


### PR DESCRIPTION
May as well give it a shot.

This upgrade does kind of suck because it renders JUnit's TemporaryFolder rule useless, and the Spock-native replacement is yet to be merged.