### PR TITLE
Try to use the same dx version as used in the project being counted

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,7 @@ tasks.withType(GroovyCompile) {
         compilerArgs << "-Xlint:all"            // Turn on all warnings
         compilerArgs << "-Xlint:-options"       // Turn off "missing" bootclasspath warning
         compilerArgs << "-Werror"               // Turn warnings into errors
+        incremental = true
         encoding = "utf-8"
         fork = true
     }

--- a/src/main/kotlin/com/getkeepsafe/dexcount/GeneratePackageTreeTask.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/GeneratePackageTreeTask.kt
@@ -348,6 +348,9 @@ abstract class Agp41LibraryPackageTreeTask @Inject constructor(
     @PathSensitive(PathSensitivity.RELATIVE)
     val aarBundleFileCollection: ConfigurableFileCollection = objects.fileCollection()
 
+    @get:Input
+    abstract val buildToolsVersion: Property<String>
+
     override var inputRepresentation: String = ""
 
     override fun generatePackageTree(): PackageTree {
@@ -360,7 +363,7 @@ abstract class Agp41LibraryPackageTreeTask @Inject constructor(
 
         val tree = PackageTree(deobfuscatorProvider.get())
 
-        val dataList = DexFile.extractDexData(aar, configProperty.get().dxTimeoutSec)
+        val dataList = DexFile.extractDexData(aar, configProperty.get().dxTimeoutSec, buildToolsVersion.get())
         try {
             for (dexFile in dataList) {
                 for (ref in dexFile.methodRefs) tree.addMethodRef(ref)

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -445,7 +445,7 @@ open class FourOneApplicator(ext: DexCountExtension, project: Project) : Abstrac
         project.plugins.withType(LibraryPlugin::class.java) {
             val android = project.extensions.getByType(LibraryExtension::class.java)
             android.onVariantProperties {
-                registerAarTask()
+                registerAarTask(android.buildToolsRevision)
             }
         }
 
@@ -531,7 +531,7 @@ open class FourOneApplicator(ext: DexCountExtension, project: Project) : Abstrac
         }
     }
 
-    protected open fun LibraryVariantProperties.registerAarTask() {
+    protected open fun LibraryVariantProperties.registerAarTask(buildToolsRevision: Revision) {
         if (!ext.enabled) {
             return
         }
@@ -551,6 +551,7 @@ open class FourOneApplicator(ext: DexCountExtension, project: Project) : Abstrac
                 t.configProperty.set(ext)
                 t.outputFileNameProperty.set(name)
                 t.aarBundleFileCollection.from(bundleTaskProvider)
+                t.buildToolsVersion.set(buildToolsRevision.toString())
                 t.loaderProperty.set(artifacts.getBuiltArtifactsLoader())
                 t.mappingFileProperty.set(artifacts.get(ArtifactType.OBFUSCATION_MAPPING_FILE))
                 t.packageTreeFileProperty.set(project.layout.buildDirectory.file("intermediates/dexcount/$name/tree.compact.gz"))

--- a/src/test/groovy/com/getkeepsafe/dexcount/DexFileSpec.groovy
+++ b/src/test/groovy/com/getkeepsafe/dexcount/DexFileSpec.groovy
@@ -42,7 +42,7 @@ final class DexFileSpec extends Specification {
         }
 
         when:
-        def dexFiles = DexFile.extractDexData(aarFile, 60)
+        def dexFiles = DexFile.extractDexData(aarFile, 60, null)
 
         then:
         dexFiles != null


### PR DESCRIPTION
Nobody has _asked_ for this but I can't help but think that it's safer to rely on the same build-tools version for _counting_ AARs as the one used to _build_ it.  Now that I know that we can, well, here we are.