### PR TITLE
Fix broken task-dependency chain under AGP < 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
             **/build-cache
+            !tmp
           key: ${{ runner.os }}-${{ matrix.jdk }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.jdk }}-gradle-

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -273,7 +273,7 @@ abstract class LegacyTaskApplicator(ext: DexCountExtension, project: Project) : 
 
             applyInputConfiguration(t)
 
-            // Depending on the runtime AGP version, inputFileProperty (as proved in applyInputConfiguration)
+            // Depending on the runtime AGP version, inputFileProperty (as provided in applyInputConfiguration)
             // may or may not carry task-dependency information with it.  We need to set that up manually here.
             t.dependsOn(parentTask)
         }

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -243,17 +243,6 @@ abstract class LegacyTaskApplicator(ext: DexCountExtension, project: Project) : 
         }
     }
 
-    protected fun addDexcountTaskToGraph(parentTask: Task, dexcountTask: Task) {
-        // Dexcount tasks require that their parent task has been run...
-        dexcountTask.dependsOn(parentTask)
-        dexcountTask.mustRunAfter(parentTask)
-
-        // But package should always imply that dexcount runs, unless configured not to.
-        if (ext.runOnEachPackage) {
-            parentTask.finalizedBy(dexcountTask)
-        }
-    }
-
     protected fun createTask(
             variant: BaseVariant,
             parentTask: TaskProvider<*>,
@@ -283,6 +272,10 @@ abstract class LegacyTaskApplicator(ext: DexCountExtension, project: Project) : 
             t.packageTreeFileProperty.set(project.layout.buildDirectory.file(treePath))
 
             applyInputConfiguration(t)
+
+            // Depending on the runtime AGP version, inputFileProperty (as proved in applyInputConfiguration)
+            // may or may not carry task-dependency information with it.  We need to set that up manually here.
+            t.dependsOn(parentTask)
         }
 
         val countTask = project.tasks.register("count${slug}DexMethods", DexCountOutputTask::class.java) { t ->


### PR DESCRIPTION
Our integration tests broke subtly, at some point in the past.  I didn't notice because our github action cached the Gradle build-cache folders in each individual integration-test, so the expected APK files were still there, despite the tasks that produce them never running.

In fact, I only noticed when switching to a new _laptop_ where I also didn't have the build-cache folders handy.

This PR fixes both the dependency problem, and the CI problem - no more caching anything to do with integration tests.

It also removes a dead function.

(fyi @ZacSweers, since you inquired privately)