### PR TITLE
Be more efficient when reading/writing thrift treegen data

### DIFF
--- a/src/main/kotlin/com/getkeepsafe/dexcount/DexCountOutputTask.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/DexCountOutputTask.kt
@@ -17,9 +17,7 @@
 package com.getkeepsafe.dexcount
 
 import com.getkeepsafe.dexcount.thrift.TreeGenOutput
-import com.microsoft.thrifty.protocol.CompactProtocol
-import com.microsoft.thrifty.transport.BufferTransport
-import okio.Buffer
+import okio.buffer
 import okio.gzip
 import okio.source
 import org.gradle.api.DefaultTask
@@ -65,13 +63,12 @@ abstract class DexCountOutputTask : DefaultTask() {
     }
 
     private fun readTreeGenFile(): TreeGenOutput {
-        return packageTreeFileProperty.asFile.get().source().gzip().use { source ->
-            val buffer = Buffer()
-            buffer.writeAll(source)
-
-            val transport = BufferTransport(buffer)
-            val protocol = CompactProtocol(transport)
-            TreeGenOutput.ADAPTER.read(protocol)
-        }
+        return packageTreeFileProperty.asFile.get()
+            .source()
+            .gzip()
+            .buffer()
+            .transport()
+            .compactProtocol()
+            .use(TreeGenOutput.ADAPTER::read)
     }
 }

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Thrifty.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Thrifty.kt
@@ -1,0 +1,41 @@
+package com.getkeepsafe.dexcount
+
+import com.microsoft.thrifty.protocol.CompactProtocol
+import com.microsoft.thrifty.transport.Transport
+import okio.BufferedSink
+
+// Write support
+
+private inline val <T> T.ignore: Unit
+    get() {}
+
+fun <S : BufferedSink> S.transport(): Transport = object : Transport() {
+    val self = this@transport
+
+    override fun close() = self.close()
+    override fun flush() = self.flush()
+
+    override fun write(data: ByteArray) = self.write(data).ignore
+    override fun write(data: ByteArray, offset: Int, count: Int) = self.write(data, offset, count).ignore
+
+    override fun read(buffer: ByteArray, offset: Int, count: Int) = error("write-only")
+}
+
+// Read support
+
+fun <S : okio.BufferedSource> S.transport(): Transport = object : Transport() {
+    private val self = this@transport
+
+    override fun close() = self.close()
+    override fun flush() {}
+
+    override fun read(buffer: ByteArray, offset: Int, count: Int) = self.read(buffer, offset, count)
+
+    override fun write(data: ByteArray) = error("read-only")
+    override fun write(buffer: ByteArray, offset: Int, count: Int) = error("read-only")
+}
+
+// Protocol support
+
+fun <T : Transport> T.compactProtocol() = CompactProtocol(this)
+


### PR DESCRIPTION
This PR streamlines the reading and writing of intermediate thrift data, allowing the possibility of streaming data to/from disk using the Okio source/sink APIs instead of reading the whole shebang into memory at once, then writing it.