### PR TITLE
Use ArtifactType.AAR in AGP 4.2+ instead of gross hack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ repositories {
     google()
 }
 
-def agpVersion = "4.2.0"
+def agpVersion = "4.2.1"
 dependencies {
     implementation platform("org.jetbrains.kotlin:kotlin-bom")
     implementation "com.google.code.gson:gson:2.8.6"

--- a/src/main/kotlin/com/getkeepsafe/dexcount/GeneratePackageTreeTask.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/GeneratePackageTreeTask.kt
@@ -306,6 +306,16 @@ abstract class BundlePackageTreeTask : ApkishPackageTreeTask() {
         get() = bundleFileProperty.asFile.get()
 }
 
+@CacheableTask
+abstract class LibraryPackageTreeTask : ApkishPackageTreeTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val aarFileProperty: RegularFileProperty
+
+    override val inputFile: File
+        get() = aarFileProperty.asFile.get()
+}
+
 // This class is so-named because there is no `ArtifactType.AAR` in AGP 4.1,
 // so we have to resort to looking up the bundle task by name, eschewing the
 // new API for the time being.  In 4.2 we'll probably be able to consolidate


### PR DESCRIPTION
Now with AGP 4.2, we can finally use the missing-in-action `ArtifactType.AAR`.  In our 4.1 implementation, we had to fish out a `BundleAar` task by name to get a handle on the AAR itself, which is inherently unstable, and also we had to use an `afterEvaluate` block which is _also_ unstable.

Now that 4.2 is here we can actually "color in the lines" so to speak and rely on the official AGP API.