### PR TITLE
Miscellaneous acts of tidiness

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,6 @@ dependencies {
     compileOnly "com.android.tools:r8:2.2.64"
     compileOnly "com.android.tools:repository:30.0.0-beta03"
     additionalPluginClasspath "com.android.tools.build:gradle:$agpVersion"
-    additionalPluginClasspath "com.android.tools:r8:2.2.64"
-    additionalPluginClasspath "com.android.tools:repository:30.0.0-beta03"
 
     testImplementation "org.codehaus.groovy:groovy-all:3.0.7"
     testImplementation "com.android.tools.build:gradle:$agpVersion"

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Deobfuscator.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Deobfuscator.kt
@@ -30,6 +30,22 @@ open class Deobfuscator(
     }
 
     companion object {
+        /**
+         * Proguard mapping files have the following syntax:
+         *
+         * ```
+         * line : comment | class_mapping | member_mapping
+         * comment: '#' ...
+         * class_mapping: type_name ' -> ' obfuscated_name ':'
+         * member_mapping: '    ' type_name ' ' member_name ' -> ' obfuscated_name
+         * ```
+         *
+         * Class mapping lines are easily distinguished because they're the only
+         * lines that start with an identifier character.  We can just pluck them
+         * out of the file with a regex.
+         */
+        private val CLASS_LINE = Regex("^([a-zA-Z][a-zA-Z0-9_.]*) -> ([^:]+):$")
+
         @JvmStatic
         fun create(mappingFile: File?): Deobfuscator {
             if (mappingFile == null) {
@@ -41,19 +57,8 @@ open class Deobfuscator(
             }
 
             val mapping = mappingFile.useLines(Charsets.UTF_8) { lines ->
-                // This is a little dense.  We're reading the mapping file line-by-line, filtering out
-                // everything except those lines that map a class to its obfuscated name.  Other line types
-                // that we filter are:
-                // - blank lines
-                // - comments (those beginning with '#')
-                // - method and field mappings (beginning with whitespace)
-                //
-                // Class mapping lines always have the form "com.foo.Bar -> a.b.c:", even when the class
-                // is empty.
-                lines.filter { it.isNotBlank() }
-                    .filterNot { it.startsWith("#") }
-                    .filterNot { it.matches(Regex("^\\s+.*")) }
-                    .map { it.split(" -> ").map { parts -> parts.removeSuffix(":") } }
+                lines
+                    .mapNotNull { CLASS_LINE.matchEntire(it)?.destructured }
                     .map { (cleartext, obfuscated) -> obfuscated to cleartext }
                     .toMap()
             }

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Deobfuscator.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Deobfuscator.kt
@@ -44,7 +44,7 @@ open class Deobfuscator(
          * lines that start with an identifier character.  We can just pluck them
          * out of the file with a regex.
          */
-        private val CLASS_LINE = Regex("^([a-zA-Z][a-zA-Z0-9_.]*) -> ([^:]+):$")
+        private val CLASS_LINE = Regex("^([a-zA-Z][^\\s]*) -> ([^:]+):$")
 
         @JvmStatic
         fun create(mappingFile: File?): Deobfuscator {

--- a/src/main/kotlin/com/getkeepsafe/dexcount/DexCountExtension.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/DexCountExtension.kt
@@ -31,21 +31,6 @@ open class DexCountExtension {
     var runOnEachPackage: Boolean = true
 
     /**
-     * When false, does not automatically count methods following the `package` task.
-     *
-     * Deprecated since 0.7.0, as dexcount no longer depends on the `assemble` task.
-     * Currently a synonym for {@link #runOnEachPackage}; will be removed in a future
-     * version.
-     */
-    @Deprecated("since 0.7.0; prefer {@link #runOnEachPackage}.", ReplaceWith("runOnEachPackage"))
-    @get:Internal("plugin input, not task input")
-    var runOnEachAssemble: Boolean
-        get() = runOnEachPackage
-        set(value) {
-            runOnEachPackage = value
-        }
-
-    /**
      * The format of the method count output, either "list", "tree", "json", or "yaml".
      */
     @get:Input
@@ -131,12 +116,6 @@ open class DexCountExtension {
      */
     @Internal("stdout-only")
     var printVersion: Boolean = false
-
-    /**
-     * Timeout when running Dx in seconds.
-     */
-    @Internal("Not input or output")
-    var dxTimeoutSec = 60
 
     /**
      * When true, then the plugin only counts the declared methods and fields inside this module.

--- a/src/main/kotlin/com/getkeepsafe/dexcount/SourceFile.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/SourceFile.kt
@@ -45,13 +45,12 @@ internal sealed class SourceFile : Closeable {
 }
 
 /**
- * A physical file and the {@link DexData} contained therein.
+ * A physical file and the [DexData] contained therein.
  *
  * A DexFile contains an open file, possibly a temp file.  When consumers are
  * finished with the DexFile, it should be cleaned up with [DexFile.close].
  */
-@Suppress("ConvertSecondaryConstructorToPrimary")
-internal class DexFile(
+internal class DexFile private constructor(
     private val file: File,
     private val isTemp: Boolean,
 ): SourceFile() {
@@ -81,13 +80,13 @@ internal class DexFile(
 
     companion object {
         /**
-         * Extracts a list of {@link DexFile} instances from the given file.
+         * Extracts a list of [DexFile] instances from the given [file].
          *
          * DexFiles can be extracted either from an Android APK file, or from a raw
-         * {@code classes.dex} file.
+         * `classes.dex` file.
          *
          * @param file the APK or dex file.
-         * @return a list of DexFile objects representing data in the given file.
+         * @return a list of [DexFile] objects representing data in the given file.
          */
         @JvmStatic
         fun extractDexData(file: File?): List<DexFile> {
@@ -151,14 +150,14 @@ internal class DexFile(
         }
 
         /**
-         * Attempts to unzip the file and extract all dex files inside of it.
+         * Attempts to unzip the [file] and extract all dex files inside of it.
          *
-         * It is assumed that {@code file} is an APK file resulting from an Android
+         * It is assumed that [file] is an APK file resulting from an Android
          * build, containing one or more appropriately-named classes.dex files.
          *
          * @param file the APK file from which to extract dex data.
          * @return a list of contained dex files.
-         * @throws ZipException if {@code file} is not a zip file.
+         * @throws ZipException if [file] is not a zip file.
          */
         @JvmStatic
         fun extractDexFromZip(file: File): List<DexFile> {


### PR DESCRIPTION
- Remove deprecated/unused bits of `DexCountExtension`
- Clean up `Deobfuscator` implementation
- Fix leftover JavaDoc syntax in SourceFile.kt