### PR TITLE
Add support for AGP 7.0.0-beta05, withdraw support for 7.1.0-alpha02

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ repositories {
     google()
 }
 
-def agpVersion = "7.1.0-alpha02"
+def agpVersion = "7.0.0-beta05"
 dependencies {
     implementation platform("org.jetbrains.kotlin:kotlin-bom")
     implementation "com.google.code.gson:gson:2.8.6"

--- a/src/integrationTest/groovy/com/getkeepsafe/dexcount/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/com/getkeepsafe/dexcount/IntegrationSpec.groovy
@@ -30,8 +30,8 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "7.1.0-alpha02" | "7.0.2"       || 7421       | 926        | 2676
-        "7.0.0-beta03"  | "7.0.2"       || 7421       | 926        | 2676
+        //"7.1.0-alpha02" | "7.0.2"       || 7421       | 926        | 2676
+        "7.0.0-beta05"  | "7.0.2"       || 7355       | 926        | 2590
         "4.2.0"         | "6.8.1"       || 7422       | 926        | 2677
         "4.1.0"         | "6.7.1"       || 7356       | 926        | 2597
         "3.6.0"         | "6.5.1"       || 7370       | 926        | 3780
@@ -60,8 +60,8 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "7.1.0-alpha02" | "7.0.2"       || 7          | 5          | 3
-        "7.0.0-beta03"  | "7.0.2"       || 7          | 5          | 3
+        //"7.1.0-alpha02" | "7.0.2"       || 7          | 5          | 3
+        "7.0.0-beta05"  | "7.0.2"       || 7          | 5          | 3
         "4.2.0"         | "6.8.1"       || 7          | 6          | 3
         "4.1.0"         | "6.7.1"       || 7          | 6          | 3
         "3.6.0"         | "6.5.1"       || 7          | 6          | 7
@@ -90,8 +90,8 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion         | gradleVersion || numMethods | numClasses | numFields
-        "7.1.0-alpha02"    | "7.0.2"       || 4266       | 723        | 1268
-        "7.0.0-beta03"     | "7.0.2"       || 4266       | 723        | 1268
+        //"7.1.0-alpha02"    | "7.0.2"       || 4266       | 723        | 1268
+        "7.0.0-beta05"     | "7.0.2"       || 4266       | 723        | 1268
         "4.2.0"            | "6.8.1"       || 4266       | 723        | 1268
         "4.1.0"            | "6.7.1"       || 4266       | 723        | 1268
         "3.6.0"            | "6.5.1"       || 4265       | 723        | 1271
@@ -120,8 +120,8 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "7.1.0-alpha02" | "7.0.2"       || 7421       | 926        | 2676
-        "7.0.0-beta03"  | "7.0.2"       || 7421       | 926        | 2676
+        //"7.1.0-alpha02" | "7.0.2"       || 7421       | 926        | 2676
+        "7.0.0-beta05"  | "7.0.2"       || 7355       | 926        | 2590
         "4.2.0"         | "6.8.1"       || 7422       | 926        | 2677
         "4.1.0"         | "6.7.1"       || 7356       | 926        | 2597
     }

--- a/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
+++ b/src/main/kotlin/com/getkeepsafe/dexcount/Plugin.kt
@@ -22,9 +22,12 @@ import com.android.build.api.artifact.Artifacts
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
-import com.android.build.api.extension.ApplicationAndroidComponentsExtension
-import com.android.build.api.extension.LibraryAndroidComponentsExtension
-import com.android.build.api.extension.TestAndroidComponentsExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
+import com.android.build.api.variant.TestAndroidComponentsExtension
+import com.android.build.api.extension.ApplicationAndroidComponentsExtension as OldApplicationAndroidComponentsExtension
+import com.android.build.api.extension.LibraryAndroidComponentsExtension as OldLibraryAndroidComponentsExtension
+import com.android.build.api.extension.TestAndroidComponentsExtension as OldTestAndroidComponentsExtension
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.LibraryExtension
@@ -59,6 +62,7 @@ import org.gradle.jvm.tasks.Jar
 import java.io.File
 import java.lang.reflect.Method
 
+@Suppress("unused")
 open class DexMethodCountPlugin : Plugin<Project> {
     companion object {
         var sdkLocation: File? = null
@@ -648,13 +652,14 @@ open class FourTwoApplicator(ext: DexCountExtension, project: Project) : FourOne
         override fun create(ext: DexCountExtension, project: Project) = FourTwoApplicator(ext, project)
     }
 
+    @Suppress("DEPRECATION")
     override fun apply() {
         if (!ext.enabled) {
             return
         }
 
         project.plugins.withType(AppPlugin::class.java).configureEach {
-            val androidComponents = project.extensions.getByType(ApplicationAndroidComponentsExtension::class.java)
+            val androidComponents = project.extensions.getByType(OldApplicationAndroidComponentsExtension::class.java)
             androidComponents.onVariants { variant ->
                 registerApkTask(variant.name, variant.artifacts)
                 registerAabTask(variant.name, variant.artifacts)
@@ -662,14 +667,14 @@ open class FourTwoApplicator(ext: DexCountExtension, project: Project) : FourOne
         }
 
         project.plugins.withType(LibraryPlugin::class.java).configureEach {
-            val androidComponents = project.extensions.getByType(LibraryAndroidComponentsExtension::class.java)
+            val androidComponents = project.extensions.getByType(OldLibraryAndroidComponentsExtension::class.java)
             androidComponents.onVariants { variant ->
                 registerAarTask(variant.name, variant.artifacts)
             }
         }
 
         project.plugins.withType(TestPlugin::class.java).configureEach {
-            val androidComponents = project.extensions.getByType(TestAndroidComponentsExtension::class.java)
+            val androidComponents = project.extensions.getByType(OldTestAndroidComponentsExtension::class.java)
             androidComponents.onVariants { variant ->
                 registerApkTask(variant.name, variant.artifacts)
             }


### PR DESCRIPTION
There was some unfortunate API breakage in beta04 and alpha03, respectively, around the packaging of `ApplicationAndroidComponentsExtension` and friends.  In the newer alpha in particular, the old versions of these classes are just gone.

7.0.0-beta05 restored the deprecated classes, at least, and so we can support it with little effort.  7.1.0 support now seems like a bigger task, likely requiring rewriting 4.2.0 to use reflection.  Because the work involved is not yet clear, I'm calling 7.1.0 "unsupported" for the time being.  When we get closer to a 7.1.0 release, we'll support it properly.