### PR TITLE
Use Commons IO instead of deprecated AntBuilder to copy directories

### DIFF
--- a/src/integrationTest/groovy/com/getkeepsafe/dexcount/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/com/getkeepsafe/dexcount/IntegrationSpec.groovy
@@ -1,5 +1,6 @@
 package com.getkeepsafe.dexcount
 
+import org.apache.commons.io.FileUtils
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Shared
@@ -128,9 +129,7 @@ class IntegrationSpec extends Specification {
 
     private File projectDir(String agpVersion, String gradleVersion) {
         def projectDir = new File(new File("tmp", gradleVersion), agpVersion)
-        new AntBuilder().copy(todir: projectDir.absolutePath) {
-            fileset(dir: integrationTestDir.absolutePath)
-        }
+        FileUtils.copyDirectory(integrationTestDir, projectDir, true)
 
         def gradleProperties = new File(projectDir, "gradle.properties")
         gradleProperties.delete()


### PR DESCRIPTION
We use `AntBuilder` in integration tests to recursively copy directories.  It's deprecated, but until the move to Java (and the adoption of Commons IO as a dependency) we didn't have a graceful alternative.  Now we do, and can remove this lurking landmine from our code.