### PR TITLE
Work around apparent bug in Gradle 6.1 DirectoryProperty#file

### DIFF
--- a/src/integrationTest/groovy/com/getkeepsafe/dexcount/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/com/getkeepsafe/dexcount/IntegrationSpec.groovy
@@ -41,6 +41,28 @@ class IntegrationSpec extends Specification {
     }
 
     @Unroll
+    def "completes successfully using AGP #agpVersion and Gradle #gradleVersion"() {
+        given: "an integration test project"
+        def project = projectDir(agpVersion, gradleVersion)
+
+        when:
+        def result = GradleRunner.create()
+            .withGradleVersion(gradleVersion)
+            .withProjectDir(project)
+            .withArguments(":app:countDebugDexMethods", "--stacktrace")
+            .build()
+
+        then:
+        result.task(":app:countDebugDexMethods").outcome == TaskOutcome.SUCCESS
+
+        // These version combinations were known to fail at some point.
+        // This spec serves to guard against regression.
+        where:
+        agpVersion | gradleVersion | reportedIn
+        "4.0.0"    | "6.1.1"       | "https://github.com/KeepSafe/dexcount-gradle-plugin/issues/410"
+    }
+
+    @Unroll
     def "counting AARs using AGP #agpVersion and Gradle #gradleVersion"() {
         given: "an integration test project"
         def project = projectDir(agpVersion, gradleVersion)

--- a/src/main/java/com/getkeepsafe/dexcount/plugin/AbstractLegacyTaskApplicator.java
+++ b/src/main/java/com/getkeepsafe/dexcount/plugin/AbstractLegacyTaskApplicator.java
@@ -143,7 +143,7 @@ abstract class AbstractLegacyTaskApplicator extends AbstractTaskApplicator {
         String treePath = path.replace("outputs", "intermediates") + "/tree.compact.gz";
 
         TaskProvider<LegacyGeneratePackageTreeTask> gen = getProject().getTasks().register(treeTaskName, LegacyGeneratePackageTreeTask.class, t -> {
-            t.setDescription("Generates dex method count for ${variant.name}.");
+            t.setDescription("Generates dex method count for " + variant.getName() + ".");
             t.setGroup("Reporting");
 
             t.getConfigProperty().set(getExt());


### PR DESCRIPTION
On Gradle 6.1.1, `getParameters().getOutputDirectory().file("summary.csv")` was failing with an error about not being able to make an absolute path from `"summary.csv"`.  Debugging confirms that we do in fact have an absolute project path stuffed into those parameters, and I'm not clear on why this error happens.  It definitely works correctly in Gradle 6.5 and later.

Working around the bug by using the `File(File, String)` constructor instead.

Also fixing one missed Kotlin string interpolation that I missed in the earlier migration.

Fixes #410