### PR TITLE
gradle-maven-publish-plugin requires new config for Maven Central

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,5 +20,8 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=keepsafe
 POM_DEVELOPER_NAME=KeepSafe Software, Inc.
 
+RELEASE_SIGNING_ENABLED=true
+SONATYPE_HOST=DEFAULT
+
 org.gradle.caching=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=1024m


### PR DESCRIPTION
Apparently in future releases, they won't publish to Sonatype Nexus automatically; some extra configuration is required.  Ditto for signing releases.

Done here, to silence warnings.