### PR TITLE
[BREAKING] Support AGP 7.4.0-alpha04, bump Java version to 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ group = GROUP
 version = VERSION_NAME
 description = POM_DESCRIPTION
 
-sourceCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_11
 
 sourceSets {
     integrationTest
@@ -180,8 +180,8 @@ tasks.register("publishEverywhere") { t ->
 // Compiler settings
 
 tasks.withType(JavaCompile) {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 
     // Show all warnings except boot classpath
     configure(options) {
@@ -195,8 +195,8 @@ tasks.withType(JavaCompile) {
 }
 
 tasks.withType(GroovyCompile) {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 
     // Show all warnings except boot classpath
     configure(options) {
@@ -236,7 +236,7 @@ tasks.withType(Test) {
 tasks.withType(Javadoc) {
     title = "${project.name} ${project.version}"
     configure(options) {
-        source = JavaVersion.VERSION_1_8
+        source = JavaVersion.VERSION_11
         header = project.name
         encoding "UTF-8"
         docEncoding "UTF-8"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,9 @@ thrifty = "3.0.0"
 [libraries]
 
 # Build + runtime dependencies
-androidTools-agp = "com.android.tools.build:gradle:7.4.0-alpha03" # Note that updates here usually require updates to androidTools-repository
+androidTools-agp = "com.android.tools.build:gradle:7.4.0-alpha04" # Note that updates here usually require updates to androidTools-repository
 androidTools-r8 = "com.android.tools:r8:3.3.28"
-androidTools-repository = "com.android.tools:repository:30.4.0-alpha03"
+androidTools-repository = "com.android.tools:repository:30.4.0-alpha04"
 autoValue-processor = { module = "com.google.auto.value:auto-value", version.ref = "autoValue" }
 autoValue-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "autoValue" }
 commons-io = "commons-io:commons-io:2.10.0"

--- a/src/integrationTest/groovy/com/getkeepsafe/dexcount/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/com/getkeepsafe/dexcount/IntegrationSpec.groovy
@@ -31,7 +31,7 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "7.4.0-alpha03" | "7.4"         || 7409       | 925        | 2666
+        "7.4.0-alpha04" | "7.4"         || 7297       | 1077       | 2666
         "7.3.0-beta02"  | "7.4"         || 7263       | 1037       | 2666
         "7.2.0"         | "7.4"         || 7410       | 925        | 2666
         "7.1.1"         | "7.4"         || 7421       | 926        | 2676
@@ -86,7 +86,7 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "7.4.0-alpha03" | "7.4"         || 7          | 5          | 3
+        "7.4.0-alpha04" | "7.4"         || 7          | 5          | 3
         "7.3.0-beta02"  | "7.4"         || 7          | 5          | 3
         "7.2.0"         | "7.4"         || 7          | 5          | 3
         "7.1.1"         | "7.4"         || 7          | 5          | 3
@@ -119,7 +119,7 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "7.4.0-alpha03" | "7.4"         || 4266       | 723        | 1268
+        "7.4.0-alpha04" | "7.4"         || 4244       | 728        | 1268
         "7.3.0-beta02"  | "7.4"         || 4244       | 728        | 1268
         "7.2.0"         | "7.4"         || 4266       | 723        | 1268
         "7.1.1"         | "7.4"         || 4266       | 723        | 1268
@@ -152,7 +152,7 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "7.4.0-alpha03" | "7.4"         || 7409       | 925        | 2666
+        "7.4.0-alpha04" | "7.4"         || 7297       | 1077       | 2666
         "7.3.0-beta02"  | "7.4"         || 7263       | 1037       | 2666
         "7.2.0"         | "7.4"         || 7410       | 925        | 2666
         "7.1.1"         | "7.4"         || 7421       | 926        | 2676


### PR DESCRIPTION
AGP 7.4.0 will apparently require Java 11.  That means we do, too.