### PR TITLE
Support AGP 8.0.0-alpha03

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,9 @@ thrifty = "3.0.0"
 [libraries]
 
 # Build + runtime dependencies
-androidTools-agp = "com.android.tools.build:gradle:8.0.0-alpha01" # Note that updates here usually require updates to androidTools-repository
+androidTools-agp = "com.android.tools.build:gradle:8.0.0-alpha03" # Note that updates here usually require updates to androidTools-repository
 androidTools-r8 = "com.android.tools:r8:3.3.28"
-androidTools-repository = "com.android.tools:repository:31.0.0-alpha01"
+androidTools-repository = "com.android.tools:repository:31.0.0-alpha03"
 autoValue-processor = { module = "com.google.auto.value:auto-value", version.ref = "autoValue" }
 autoValue-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "autoValue" }
 commons-io = "commons-io:commons-io:2.10.0"

--- a/src/integrationTest/groovy/com/getkeepsafe/dexcount/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/com/getkeepsafe/dexcount/IntegrationSpec.groovy
@@ -31,7 +31,7 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "8.0.0-alpha01" | "7.5"         || 6937       | 1019       | 2527
+        "8.0.0-alpha03" | "7.5"         || 6938       | 1022       | 2527
         "7.4.0-beta01"  | "7.5"         || 7289       | 1072       | 2657
         "7.3.0"         | "7.5"         || 7263       | 1037       | 2666
         "7.2.2"         | "7.5"         || 7410       | 925        | 2666
@@ -87,7 +87,7 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "8.0.0-alpha01" | "7.5"         || 7          | 5          | 3
+        "8.0.0-alpha03" | "7.5"         || 7          | 5          | 3
         "7.4.0-beta01"  | "7.5"         || 7          | 5          | 3
         "7.3.0"         | "7.5"         || 7          | 5          | 3
         "7.2.2"         | "7.5"         || 7          | 5          | 3
@@ -121,17 +121,17 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "8.0.0-alpha01" | "7.5"         || 4244       | 728        | 1268
-        "7.4.0-beta01"  | "7.5"         || 4244       | 728        | 1268
-        "7.3.0"         | "7.5"         || 4244       | 728        | 1268
+        "8.0.0-alpha03" | "7.5"         || 4242       | 726        | 1268
+        "7.4.0-beta01"  | "7.5"         || 4277       | 745        | 1284
+        "7.3.0"         | "7.5"         || 4277       | 745        | 1284
         "7.2.2"         | "7.5"         || 4266       | 723        | 1268
         "7.1.1"         | "7.5"         || 4266       | 723        | 1268
         "7.0.0"         | "7.5"         || 4266       | 723        | 1268
         "4.2.0"         | "6.8.1"       || 4266       | 723        | 1268
         "4.1.0"         | "6.7.1"       || 4266       | 723        | 1268
-        "3.6.0"         | "6.5.1"       || 4265       | 723        | 1271
-        "3.5.4"         | "6.5.1"       || 4266       | 723        | 1271
-        "3.4.0"         | "6.5.1"       || 4267       | 723        | 1271
+        "3.6.0"         | "6.5.1"       || 4298       | 740        | 1287
+        "3.5.4"         | "6.5.1"       || 4299       | 740        | 1287
+        "3.4.0"         | "6.5.1"       || 4300       | 740        | 1287
     }
 
     @Unroll
@@ -155,7 +155,7 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "8.0.0-alpha01" | "7.5"         || 6937       | 1019       | 2527
+        "8.0.0-alpha03" | "7.5"         || 6938       | 1022       | 2527
         "7.4.0-beta01"  | "7.5"         || 7289       | 1072       | 2657
         "7.3.0"         | "7.5"         || 7263       | 1037       | 2666
         "7.2.2"         | "7.5"         || 7410       | 925        | 2666

--- a/src/integrationTest/projects/integration/app/build.gradle
+++ b/src/integrationTest/projects/integration/app/build.gradle
@@ -6,6 +6,12 @@ plugins {
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
+    try {
+        namespace "com.getkeepsafe.dexcount.integration"
+    } catch (Throwable ignored) {
+        // Expected on AGP < 8.0.0
+    }
+
     defaultConfig {
         applicationId "com.getkeepsafe.dexcount.integration"
         minSdkVersion rootProject.ext.minSdkVersion

--- a/src/integrationTest/projects/integration/lib/build.gradle
+++ b/src/integrationTest/projects/integration/lib/build.gradle
@@ -6,6 +6,12 @@ plugins {
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
+    try {
+        namespace "com.getkeepsafe.dexcount.integration"
+    } catch (Throwable ignored) {
+        // Expected on AGP < 8.0.0
+    }
+
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/src/integrationTest/projects/integration/tests/build.gradle
+++ b/src/integrationTest/projects/integration/tests/build.gradle
@@ -4,6 +4,12 @@ plugins {
 }
 
 android {
+    try {
+        namespace "com.getkeepsafe.dexcount.integration.tests"
+    } catch (Throwable ignored) {
+        // Expected on AGP < 8.0.0
+    }
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
@@ -32,11 +38,7 @@ android {
 
 dependencies {
     // Android Testing Support Library"s runner and rules and hamcrest matchers
-    implementation dependencies.create("com.android.support.test:runner:1.0.2") {
-        exclude module: 'support-annotations'
-    }
-    implementation dependencies.create("com.android.support.test:rules:1.0.2") {
-        exclude module: 'support-annotations'
-    }
+    implementation "com.android.support.test:runner:1.0.2"
+    implementation "com.android.support.test:rules:1.0.2"
     implementation "org.hamcrest:hamcrest-core:1.3"
 }


### PR DESCRIPTION
This is the first AGP version to require `android.namespace` over package names in AndroidManifest.xml; the test projects have to do this in a try/ignore block and continue to use AndroidManifest.xml.

Something in R8 (I think?) has changed since 8.0.0-alpha01, and the test project fails to build with errors about missing support-annotation classes.  I don't really get that - they're source-only retention - but sure enough, we'd excluded them at some point in the past from the test project.  Likely it was for AGP versions older than 3.4.0, our minimum supported version.

Un-excluding them fixes the build, but changes the counts for many (but not all) of the test-project builds.