### PR TITLE
Bump Gradle, AGP 8.0.0 and 8.1.0 previews

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -309,6 +309,6 @@ tasks.register("uploadSnapshot") {
 }
 
 wrapper {
-    gradleVersion = "7.6"
+    gradleVersion = "8.0.2"
     distributionType = Wrapper.DistributionType.ALL
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,9 @@ thrifty = "3.1.0"
 [libraries]
 
 # Build + runtime dependencies
-androidTools-agp = "com.android.tools.build:gradle:8.1.0-alpha02" # Note that updates here usually require updates to androidTools-repository
+androidTools-agp = "com.android.tools.build:gradle:8.1.0-alpha08" # Note that updates here usually require updates to androidTools-repository
 androidTools-r8 = "com.android.tools:r8:4.0.48"
-androidTools-repository = "com.android.tools:repository:31.1.0-alpha02"
+androidTools-repository = "com.android.tools:repository:31.1.0-alpha08"
 autoValue-processor = { module = "com.google.auto.value:auto-value", version.ref = "autoValue" }
 autoValue-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "autoValue" }
 commons-io = "commons-io:commons-io:2.10.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-rc-2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/integrationTest/groovy/com/getkeepsafe/dexcount/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/com/getkeepsafe/dexcount/IntegrationSpec.groovy
@@ -32,8 +32,8 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "8.1.0-alpha02" | "8.0-rc-1"    || 6938       | 1029       | 2528
-        "8.0.0-beta01"  | "8.0-rc-1"    || 6935       | 1026       | 2528
+        "8.1.0-alpha08" | "8.0.2"       || 6941       | 1030       | 2528
+        "8.0.0-beta04"  | "8.0.2"       || 6935       | 1026       | 2528
         "7.4.1"         | "7.6"         || 7273       | 1065       | 2657
         "7.3.1"         | "7.6"         || 7263       | 1037       | 2666
         "7.2.2"         | "7.6"         || 7410       | 925        | 2666
@@ -85,8 +85,8 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "8.1.0-alpha02" | "8.0-rc-1"    || 4          | 3          | 0
-        "8.0.0-beta01"  | "8.0-rc-1"    || 4          | 3          | 0
+        "8.1.0-alpha08" | "8.0.2"       || 4          | 3          | 0
+        "8.0.0-beta04"  | "8.0.2"       || 4          | 3          | 0
         "7.4.1"         | "7.6"         || 7          | 5          | 3
         "7.3.1"         | "7.6"         || 7          | 5          | 3
         "7.2.2"         | "7.6"         || 7          | 5          | 3
@@ -115,8 +115,8 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "8.1.0-alpha02" | "8.0-rc-1"    || 4240       | 725        | 1265
-        "8.0.0-beta01"  | "8.0-rc-1"    || 4240       | 725        | 1265
+        "8.1.0-alpha08" | "8.0.2"       || 4240       | 725        | 1265
+        "8.0.0-beta04"  | "8.0.2"       || 4240       | 725        | 1265
         "7.4.1"         | "7.6"         || 4242       | 726        | 1268
         "7.3.1"         | "7.6"         || 4277       | 745        | 1284
         "7.2.2"         | "7.6"         || 4266       | 723        | 1268
@@ -145,8 +145,8 @@ class IntegrationSpec extends Specification {
 
         where:
         agpVersion      | gradleVersion || numMethods | numClasses | numFields
-        "8.1.0-alpha02" | "8.0-rc-1"    || 6938       | 1029       | 2528
-        "8.0.0-beta01"  | "8.0-rc-1"    || 6935       | 1026       | 2528
+        "8.1.0-alpha08" | "8.0.2"       || 6941       | 1030       | 2528
+        "8.0.0-beta04"  | "8.0.2"       || 6935       | 1026       | 2528
         "7.4.1"         | "7.6"         || 7273       | 1065       | 2657
         "7.3.1"         | "7.6"         || 7263       | 1037       | 2666
         "7.2.2"         | "7.6"         || 7410       | 925        | 2666


### PR DESCRIPTION
Due to an [AGP issue](https://issuetracker.google.com/issues/265809620), and the fact that both AGP previews we build and test against don't have the related fix, we have to update our Gradle version and our AGP previews in tandem.  This is a larger PR than usual as a result, but thankfully is otherwise without totally routine.