### PR TITLE
Use Gradle min-version attribute instead of explicit version check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.gradle.api.attributes.plugin.GradlePluginApiVersion
+
 plugins {
     id "groovy"
     id "java-gradle-plugin"
@@ -59,6 +61,18 @@ configurations {
     compileOnly {
         extendsFrom androidBuildTool
         extendsFrom workerImplementation
+    }
+
+    runtimeElements {
+        attributes {
+            attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, objects.named(GradlePluginApiVersion, MIN_GRADLE_VERSION))
+        }
+    }
+
+    apiElements {
+        attributes {
+            attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, objects.named(GradlePluginApiVersion, MIN_GRADLE_VERSION))
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,8 @@
 GROUP=com.getkeepsafe.dexcount
 VERSION_NAME=4.0.1-SNAPSHOT
 
+MIN_GRADLE_VERSION=7.0
+
 POM_ARTIFACT_ID=dexcount-gradle-plugin
 POM_NAME=Dexcount Gradle Plugin
 POM_PACKAGING=jar

--- a/src/main/java/com/getkeepsafe/dexcount/DexMethodCountPlugin.java
+++ b/src/main/java/com/getkeepsafe/dexcount/DexMethodCountPlugin.java
@@ -22,7 +22,6 @@ import com.getkeepsafe.dexcount.plugin.TaskApplicators;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.logging.configuration.ShowStacktrace;
-import org.gradle.util.GradleVersion;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
@@ -33,17 +32,10 @@ public class DexMethodCountPlugin implements Plugin<Project> {
     private static final String VERSION_7_0_FIELD = "com.android.Version"; // >= 7.0
     private static final String AGP_VERSION_FIELD = "ANDROID_GRADLE_PLUGIN_VERSION";
 
-    private static final GradleVersion MIN_GRADLE_VERSION = GradleVersion.version("7.0");
     private static final Revision MIN_AGP_VERSION = new Revision(3, 4, 0);
 
     @Override
     public void apply(@NotNull Project project) {
-        GradleVersion gradleVersion = GradleVersion.version(project.getGradle().getGradleVersion());
-        if (gradleVersion.compareTo(MIN_GRADLE_VERSION) < 0) {
-            project.getLogger().error("dexcount requires Gradle {} or above", MIN_GRADLE_VERSION);
-            return;
-        }
-
         Revision gradlePluginRevision = getCurrentAgpRevision();
         DexCountExtension ext = project.getExtensions().create("dexcount", DexCountExtension.class);
 
@@ -73,8 +65,7 @@ public class DexMethodCountPlugin implements Plugin<Project> {
             applicator.apply();
         } else {
             project.getLogger().error(
-                "No dexcount TaskApplicator configured for Gradle version {} and AGP version {}",
-                gradleVersion,
+                "No dexcount TaskApplicator configured for AGP version {}",
                 gradlePluginRevision);
         }
     }


### PR DESCRIPTION
This moves the failure case forward quite a lot - projects on older gradle versions will simply fail to configure, rather than fail at build-time.  It won't be possible for them to even depend on dexcount.